### PR TITLE
Fix PDD bot (TODO -> NOTE)

### DIFF
--- a/eo-phi-normalizer/Setup.hs
+++ b/eo-phi-normalizer/Setup.hs
@@ -25,7 +25,7 @@ main = defaultMainWithHooks $ simpleUserHooks
       postConf simpleUserHooks args flags packageDesc localBuildInfo
   }
 
--- | TODO: This should be in Cabal.Distribution.Simple.Program.Builtin.
+-- | NOTE: This should be in Cabal.Distribution.Simple.Program.Builtin.
 bnfcProgram :: Program
 bnfcProgram = (simpleProgram "bnfc")
   { programFindVersion = findProgramVersion "--version" id


### PR DESCRIPTION
There was a `TODO` note in `Setup.hs` that was a `NOTE` in spirit. Should fix PDD bot.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on a minor change in the code. 

### Detailed summary:
- Changed a comment from TODO to NOTE in `Setup.hs` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->