### PR TITLE
Rule condition: attribute presence/absence

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -39,7 +39,6 @@ main = do
   opts <- getRecord "Normalizer"
   let (CLIOptions params inPath) = opts
   let (CLINamedParams{..}) = params
-  Control.Monad.when chain (putStrLn "Sorry, --chain is not implemented yet 😅")
   case rulesYaml of
     Just path -> do
       ruleSet <- parseRuleSetFromFile path

--- a/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
+++ b/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
@@ -35,6 +35,11 @@ Label.  Attribute ::= LabelId ;
 Alpha.  Attribute ::= AlphaIndex ;
 MetaAttr. Attribute ::= MetaId ;
 
+-- Additional symbols used as attributes in the rules
+ObjectAttr. RuleAttribute ::= Attribute ;
+DeltaAttr.  RuleAttribute ::= "Δ" ;
+LambdaAttr. RuleAttribute ::= "λ" ;
+
 PeeledObject. PeeledObject ::= ObjectHead [ObjectAction] ;
 
 HeadFormation.    ObjectHead ::= "⟦" [Binding] "⟧" ;

--- a/eo-phi-normalizer/src/Language/EO/Phi.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Language.EO.Phi (
   defaultMain,
   normalize,

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -18,6 +18,7 @@ instance IsString Program where fromString = unsafeParseWith pProgram
 instance IsString Object where fromString = unsafeParseWith pObject
 instance IsString Binding where fromString = unsafeParseWith pBinding
 instance IsString Attribute where fromString = unsafeParseWith pAttribute
+instance IsString RuleAttribute where fromString = unsafeParseWith pRuleAttribute
 instance IsString PeeledObject where fromString = unsafeParseWith pPeeledObject
 instance IsString ObjectHead where fromString = unsafeParseWith pObjectHead
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -18,7 +18,12 @@ import Language.EO.Phi.Rules.Common qualified as Common
 import Language.EO.Phi.Syntax.Abs
 
 instance FromJSON Object where parseJSON = fmap fromString . parseJSON
+instance FromJSON Binding where parseJSON = fmap fromString . parseJSON
 instance FromJSON MetaId where parseJSON = fmap MetaId . parseJSON
+instance FromJSON Attribute where parseJSON = fmap fromString . parseJSON
+
+instance FromJSON LabelId
+instance FromJSON AlphaIndex
 
 data RuleSet = RuleSet
   { title :: String

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -5,10 +5,12 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
 
 module Language.EO.Phi.Rules.Yaml where
 
-import Data.Aeson (FromJSON (..))
+import Data.Aeson (FromJSON (..), Options (sumEncoding), SumEncoding (UntaggedValue), genericParseJSON)
+import Data.Aeson.Types (defaultOptions)
 import Data.Coerce (coerce)
 import Data.Maybe (fromMaybe)
 import Data.String (IsString (..))
@@ -49,8 +51,18 @@ data RuleTest = RuleTest
   }
   deriving (Generic, FromJSON, Show)
 
-data Condition = IsNF {nf :: [MetaId]}
-  deriving (Generic, FromJSON, Show)
+data Subset = Subset
+  { attrs :: [Attribute]
+  , bindings :: [Binding]
+  }
+  deriving (Generic, Show, FromJSON)
+data Condition
+  = IsNF {nf :: [MetaId]}
+  | IsSubset {subset :: Subset}
+  | NotSubset {not_subset :: Subset}
+  deriving (Generic, Show)
+instance FromJSON Condition where
+  parseJSON = genericParseJSON defaultOptions{sumEncoding = UntaggedValue}
 
 parseRuleSetFromFile :: FilePath -> IO RuleSet
 parseRuleSetFromFile = Yaml.decodeFileThrow

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
@@ -46,6 +46,9 @@ data Attribute
     | MetaAttr MetaId
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
 
+data RuleAttribute = ObjectAttr Attribute | DeltaAttr | LambdaAttr
+  deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
+
 data PeeledObject = PeeledObject ObjectHead [ObjectAction]
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
@@ -80,6 +80,9 @@ All other symbols are terminals.
   |  |  **|**  | //LabelId//
   |  |  **|**  | //AlphaIndex//
   |  |  **|**  | //MetaId//
+  | //RuleAttribute// | -> | //Attribute//
+  |  |  **|**  | ``Δ``
+  |  |  **|**  | ``λ``
   | //PeeledObject// | -> | //ObjectHead// //[ObjectAction]//
   | //ObjectHead// | -> | ``⟦`` //[Binding]// ``⟧``
   |  |  **|**  | ``Φ``

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
@@ -13,6 +13,7 @@ module Language.EO.Phi.Syntax.Par
   , pBinding
   , pListBinding
   , pAttribute
+  , pRuleAttribute
   , pPeeledObject
   , pObjectHead
   , pObjectAction
@@ -31,6 +32,7 @@ import Language.EO.Phi.Syntax.Lex
 %name pBinding Binding
 %name pListBinding ListBinding
 %name pAttribute Attribute
+%name pRuleAttribute RuleAttribute
 %name pPeeledObject PeeledObject
 %name pObjectHead ObjectHead
 %name pObjectAction ObjectAction
@@ -119,6 +121,12 @@ Attribute
   | LabelId { Language.EO.Phi.Syntax.Abs.Label $1 }
   | AlphaIndex { Language.EO.Phi.Syntax.Abs.Alpha $1 }
   | MetaId { Language.EO.Phi.Syntax.Abs.MetaAttr $1 }
+
+RuleAttribute :: { Language.EO.Phi.Syntax.Abs.RuleAttribute }
+RuleAttribute
+  : Attribute { Language.EO.Phi.Syntax.Abs.ObjectAttr $1 }
+  | 'Δ' { Language.EO.Phi.Syntax.Abs.DeltaAttr }
+  | 'λ' { Language.EO.Phi.Syntax.Abs.LambdaAttr }
 
 PeeledObject :: { Language.EO.Phi.Syntax.Abs.PeeledObject }
 PeeledObject

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
@@ -184,6 +184,12 @@ instance Print Language.EO.Phi.Syntax.Abs.Attribute where
     Language.EO.Phi.Syntax.Abs.Alpha alphaindex -> prPrec i 0 (concatD [prt 0 alphaindex])
     Language.EO.Phi.Syntax.Abs.MetaAttr metaid -> prPrec i 0 (concatD [prt 0 metaid])
 
+instance Print Language.EO.Phi.Syntax.Abs.RuleAttribute where
+  prt i = \case
+    Language.EO.Phi.Syntax.Abs.ObjectAttr attribute -> prPrec i 0 (concatD [prt 0 attribute])
+    Language.EO.Phi.Syntax.Abs.DeltaAttr -> prPrec i 0 (concatD [doc (showString "\916")])
+    Language.EO.Phi.Syntax.Abs.LambdaAttr -> prPrec i 0 (concatD [doc (showString "\955")])
+
 instance Print Language.EO.Phi.Syntax.Abs.PeeledObject where
   prt i = \case
     Language.EO.Phi.Syntax.Abs.PeeledObject objecthead objectactions -> prPrec i 0 (concatD [prt 0 objecthead, prt 0 objectactions])

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -69,7 +69,7 @@ rules:
     pattern: |
       ⟦ φ ↦ !n, !B ⟧.!a
     result: |
-      !n
+      !n.!a
     when:
       - nf: ["!n"]
       - absent_attrs:

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -7,10 +7,10 @@ rules:
     result: |
       ⟦ !B, ρ ↦ ξ.σ ⟧
     when:
-      - subset:
+      - present_attrs:
           attrs: ["σ"]
           bindings: ["!B"]
-      - not_subset:
+      - absent_attrs:
           attrs: ["ρ"]
           bindings: ["!B"]
     tests: []
@@ -60,7 +60,7 @@ rules:
       !n
     when:
       - nf: ["!n"]
-      - not_subset:
+      - absent_attrs:
           attrs: ["!a"]
           bindings: ["!B"]
     tests: []
@@ -80,10 +80,10 @@ rules:
     result: |
       ⊥
     when:
-      - not_subset:
+      - absent_attrs:
           attrs: ["!a", "Φ", "λ"]
           bindings: ["!B"]
-      - subset:
+      - present_attrs:
           attrs: ["ρ", "σ"]
           bindings: ["!B"]
     tests: []

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -1,5 +1,20 @@
 title: "Rule set based on Yegor's draft"
 rules:
+  - name: Rule 3
+    description: ""
+    pattern: |
+      ⟦ !B ⟧
+    result: |
+      ⟦ !B, ρ ↦ ξ.σ ⟧
+    when:
+      - subset:
+          attrs: ["σ"]
+          bindings: ["!B"]
+      - not_subset:
+          attrs: ["ρ"]
+          bindings: ["!B"]
+    tests: []
+
   - name: Rule 5
     description: "ξ-dispatch"
     pattern: |
@@ -37,7 +52,18 @@ rules:
       - nf: ["!n"]
     tests: []
 
-  # - name: Rule 8
+  - name: Rule 8
+    description: ""
+    pattern: |
+      ⟦ φ ↦ !n, !B ⟧.!a
+    result: |
+      !n
+    when:
+      - nf: ["!n"]
+      - not_subset:
+          attrs: ["!a"]
+          bindings: ["!B"]
+    tests: []
 
   - name: Rule 9
     description: "Parent application"
@@ -45,4 +71,19 @@ rules:
     result: ⟦ ρ ↦ !n, !B ⟧
     when:
       - nf: ["!n"]
+    tests: []
+
+  - name: Rule 11
+    description: ""
+    pattern: |
+      ⟦ !B ⟧.!a
+    result: |
+      ⊥
+    when:
+      - not_subset:
+          attrs: ["!a", "Φ", "λ"]
+          bindings: ["!B"]
+      - subset:
+          attrs: ["ρ", "σ"]
+          bindings: ["!B"]
     tests: []

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -101,7 +101,7 @@ rules:
       ⊥
     when:
       - absent_attrs:
-          attrs: ["!a", "Φ", "λ"]
+          attrs: ["!a", "φ", "λ"]
           bindings: ["!B"]
       - present_attrs:
           attrs: ["ρ", "σ"]

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -13,7 +13,19 @@ rules:
       - absent_attrs:
           attrs: ["ρ"]
           bindings: ["!B"]
-    tests: []
+    tests:
+      - name: 'Has sigma and no rho'
+        input: '⟦ b ↦ ⟦ ⟧, σ ↦ ⟦ ⟧ ⟧ '
+        output: '⟦ b ↦ ⟦ ⟧, σ ↦ ⟦ ⟧, ρ ↦ ξ.σ ⟧'
+        matches: true
+      - name: 'Has both sigma and rho'
+        input: '⟦ a ↦ ⟦ b ↦ ⟦ ⟧, ρ ↦ ⟦ ⟧, σ ↦ ⟦ ⟧ ⟧ ⟧'
+        output: '⟦ a ↦ ⟦ b ↦ ⟦ ⟧, ρ ↦ ⟦ ⟧, σ ↦ ⟦ ⟧ ⟧ ⟧'
+        matches: false
+      - name: 'Has neither sigma nor rho'
+        input: '⟦ a ↦ ⟦ b ↦ ⟦ ⟧ ⟧ ⟧'
+        output: '⟦ a ↦ ⟦ b ↦ ⟦ ⟧ ⟧ ⟧'
+        matches: false
 
   - name: Rule 5
     description: "ξ-dispatch"
@@ -63,7 +75,15 @@ rules:
       - absent_attrs:
           attrs: ["!a"]
           bindings: ["!B"]
-    tests: []
+    tests:
+      - name: 'Attribute does not exist'
+        input: '⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧.b'
+        output: '⟦ ⟧.b'
+        matches: true
+      - name: 'Attribute exists'
+        input: '⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧.a'
+        output: '⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧.a'
+        matches: false
 
   - name: Rule 9
     description: "Parent application"
@@ -86,4 +106,8 @@ rules:
       - present_attrs:
           attrs: ["ρ", "σ"]
           bindings: ["!B"]
-    tests: []
+    tests:
+      - name: 'Accessing nonexistent attribute'
+        input: '⟦ ρ ↦ ⟦ ⟧, σ ↦ ⟦ ⟧ ⟧.x'
+        output: '⊥'
+        matches: true


### PR DESCRIPTION
Closes #55

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding new attributes and conditions to the EO Phi language. 

### Detailed summary
- Added new symbols as attributes in the rules
- Added new data types for RuleAttribute in Syntax
- Updated the parser to recognize RuleAttribute
- Added instance for IsString for RuleAttribute
- Updated the printer to handle RuleAttribute
- Added new conditions for rule matching
- Updated the YAML parser to handle RuleAttribute
- Added new test cases for the updated rules

> The following files were skipped due to too many changes: `eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->