### PR TITLE
Fix TODO format for PDD bot

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -53,7 +53,7 @@ main = do
                 | otherwise = pure <$> applyRules (Context (convertRule <$> ruleSet.rules)) (Formation bindings)
               uniqueResults = nub results
               totalResults = length uniqueResults
-          -- TODO: use outPath to output to file if provided
+          -- TODO #48:15m use outPath to output to file if provided
           putStrLn "Input:"
           putStrLn (printTree input)
           putStrLn "===================================================="
@@ -66,5 +66,5 @@ main = do
                 putStr ("[ " <> show k <> " / " <> show n <> " ]")
               putStrLn (printTree step)
             putStrLn "----------------------------------------------------"
-    -- TODO: still need to consider `chain`
+    -- TODO #48:15m still need to consider `chain` (should rewrite/change defaultMain to mainWithOptions)
     Nothing -> defaultMain


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR focuses on using the `outPath` variable to output to a file if provided. It also addresses the need to consider the `chain` variable in the `main` function. 

Notable changes:
- Added a TODO comment to use `outPath` to output to a file if provided
- Added a TODO comment to consider the `chain` variable in the `main` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->