### PR TITLE
Fix TODO format for PDD bot in Language.EO.Phi.Rules.Yaml

### DIFF
--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -75,7 +75,7 @@ convertRule Rule{..} ctx obj =
   | subst <- matchObject pattern obj
   , all (\cond -> checkCond ctx cond subst) when
   , obj' <- [applySubst subst result]
-  -- TODO: check that obj' does not have any metavariables
+  -- TODO #82:20m check that obj' does not have any metavariables
   ]
 
 -- | Given a condition, and a substition from object matching


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on checking that `obj'` in `Yaml.hs` does not have any metavariables. 

### Detailed summary
- Added a TODO comment to check that `obj'` does not have any metavariables

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->