### PR TITLE
Ensure the rule conversion leaves no metavariables

### DIFF
--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -79,13 +79,13 @@ convertRule Rule{..} ctx obj =
   ]
 
 objectHasMetavars :: Object -> Bool
-objectHasMetavars (MetaObject _) = True
 objectHasMetavars (Formation bindings) = any bindingHasMetavars bindings
 objectHasMetavars (Application object bindings) = objectHasMetavars object || any bindingHasMetavars bindings
 objectHasMetavars (ObjectDispatch object attr) = objectHasMetavars object || attrHasMetavars attr
 objectHasMetavars (GlobalDispatch attr) = attrHasMetavars attr
 objectHasMetavars (ThisDispatch attr) = attrHasMetavars attr
 objectHasMetavars Termination = False
+objectHasMetavars (MetaObject _) = True
 
 bindingHasMetavars :: Binding -> Bool
 bindingHasMetavars (AlphaBinding attr obj) = attrHasMetavars attr || objectHasMetavars obj
@@ -95,13 +95,13 @@ bindingHasMetavars (LambdaBinding _) = False
 bindingHasMetavars (MetaBindings _) = True
 
 attrHasMetavars :: Attribute -> Bool
-attrHasMetavars (MetaAttr _) = True
 attrHasMetavars Phi = False
 attrHasMetavars Rho = False
 attrHasMetavars Sigma = False
 attrHasMetavars VTX = False
 attrHasMetavars (Label _) = False
 attrHasMetavars (Alpha _) = False
+attrHasMetavars (MetaAttr _) = True
 
 -- | Given a condition, and a substition from object matching
 --   tells whether the condition matches the object

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -85,7 +85,7 @@ objectHasMetavars (Application object bindings) = objectHasMetavars object || an
 objectHasMetavars (ObjectDispatch object attr) = objectHasMetavars object || attrHasMetavars attr
 objectHasMetavars (GlobalDispatch attr) = attrHasMetavars attr
 objectHasMetavars (ThisDispatch attr) = attrHasMetavars attr
-objectHasMetavars _ = False
+objectHasMetavars Termination = False
 
 bindingHasMetavars :: Binding -> Bool
 bindingHasMetavars (AlphaBinding attr obj) = attrHasMetavars attr || objectHasMetavars obj
@@ -96,7 +96,12 @@ bindingHasMetavars (MetaBindings _) = True
 
 attrHasMetavars :: Attribute -> Bool
 attrHasMetavars (MetaAttr _) = True
-attrHasMetavars _ = False
+attrHasMetavars Phi = False
+attrHasMetavars Rho = False
+attrHasMetavars Sigma = False
+attrHasMetavars VTX = False
+attrHasMetavars (Label _) = False
+attrHasMetavars (Alpha _) = False
 
 -- | Given a condition, and a substition from object matching
 --   tells whether the condition matches the object


### PR DESCRIPTION
Closes #82

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new function `objectHasMetavars` to check if an object contains any metavariables.
- Added helper functions `bindingHasMetavars` and `attrHasMetavars` to check if a binding or attribute contains any metavariables.
- Updated the `checkCond` function to use the new `objectHasMetavars` function to check for metavariables in objects.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->