### PR TITLE
Fix grammar

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -36,8 +36,7 @@ jobs:
             !eo-phi-normalizer/Setup.hs
 
       - name: 🧰 Setup Stack
-        # FIXME use freckle/stack-action@v5 when https://github.com/freckle/stack-action/pull/36 is merged
-        uses: freckle/stack-action@pb/v5
+        uses: freckle/stack-action@v5
         with:
           stack-build-arguments: --${{ github.ref_name != 'master' && 'fast' || '' }} --pedantic
 
@@ -54,8 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🧰 Setup Stack
-        # FIXME use freckle/stack-action@v5 when https://github.com/freckle/stack-action/pull/36 is merged
-        uses: freckle/stack-action@pb/v5
+        uses: freckle/stack-action@v5
         with:
           stack-build-arguments: --${{ github.ref_name != 'master' && 'fast' || '' }} --pedantic
 

--- a/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
+++ b/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
@@ -6,7 +6,7 @@
 
 token Bytes ({"--"} | ["0123456789ABCDEF"] ["0123456789ABCDEF"] {"-"} | ["0123456789ABCDEF"] ["0123456789ABCDEF"] ({"-"} ["0123456789ABCDEF"] ["0123456789ABCDEF"])+) ;
 token Function upper (char - [" \r\n\t,.|':;!-?][}{)(⟧⟦"])* ;
-token LabelId  lower (char - [" \r\n\t,.|':;!-?][}{)(⟧⟦"])* ;
+token LabelId  lower (char - [" \r\n\t,.|':;!?][}{)(⟧⟦"])* ;
 token AlphaIndex ({"α0"} | {"α"} (digit - ["0"]) (digit)* ) ;
 token MetaId {"!"} (char - [" \r\n\t,.|':;!-?][}{)(⟧⟦"])* ;
 
@@ -15,8 +15,8 @@ Program. Program ::= "{" [Binding] "}" ;
 Formation.      Object ::= "⟦" [Binding] "⟧" ;
 Application.    Object ::= Object "(" [Binding] ")" ;
 ObjectDispatch. Object ::= Object "." Attribute ;
-GlobalDispatch. Object ::= "Φ" "." Attribute ;
-ThisDispatch.   Object ::= "ξ" "." Attribute ;
+GlobalObject.   Object ::= "Φ";
+ThisObject.     Object ::= "ξ";
 Termination.    Object ::= "⊥" ;
 MetaObject.     Object ::= MetaId ;
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -61,8 +61,8 @@ withSubObject f root =
           , Application obj <$> withSubObjectBindings f bindings
           ]
       ObjectDispatch obj a -> ObjectDispatch <$> withSubObject f obj <*> pure a
-      GlobalDispatch{} -> []
-      ThisDispatch{} -> []
+      GlobalObject{} -> []
+      ThisObject{} -> []
       Termination -> []
       MetaObject _ -> []
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -82,8 +82,8 @@ objectHasMetavars :: Object -> Bool
 objectHasMetavars (Formation bindings) = any bindingHasMetavars bindings
 objectHasMetavars (Application object bindings) = objectHasMetavars object || any bindingHasMetavars bindings
 objectHasMetavars (ObjectDispatch object attr) = objectHasMetavars object || attrHasMetavars attr
-objectHasMetavars (GlobalDispatch attr) = attrHasMetavars attr
-objectHasMetavars (ThisDispatch attr) = attrHasMetavars attr
+objectHasMetavars GlobalObject = False
+objectHasMetavars ThisObject = False
 objectHasMetavars Termination = False
 objectHasMetavars (MetaObject _) = True
 
@@ -172,10 +172,8 @@ applySubst subst@Subst{..} = \case
     Application (applySubst subst obj) (applySubstBindings subst bindings)
   ObjectDispatch obj a ->
     ObjectDispatch (applySubst subst obj) (applySubstAttr subst a)
-  GlobalDispatch a ->
-    GlobalDispatch (applySubstAttr subst a)
-  ThisDispatch a ->
-    ThisDispatch (applySubstAttr subst a)
+  GlobalObject -> GlobalObject
+  ThisObject -> ThisObject
   obj@(MetaObject x) -> fromMaybe obj $ lookup x objectMetas
   obj -> obj
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
@@ -22,8 +22,8 @@ data Object
     = Formation [Binding]
     | Application Object [Binding]
     | ObjectDispatch Object Attribute
-    | GlobalDispatch Attribute
-    | ThisDispatch Attribute
+    | GlobalObject
+    | ThisObject
     | Termination
     | MetaObject MetaId
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
@@ -26,7 +26,7 @@ Function literals are recognized by the regular expression
 
 LabelId literals are recognized by the regular expression
 `````lower (char - ["
- !'(),-.:;?[]{|}⟦⟧"])*`````
+ !'(),.:;?[]{|}⟦⟧"])*`````
 
 AlphaIndex literals are recognized by the regular expression
 `````{"α0"} | 'α' (digit - '0') digit*`````
@@ -61,8 +61,8 @@ All other symbols are terminals.
   | //Object// | -> | ``⟦`` //[Binding]// ``⟧``
   |  |  **|**  | //Object// ``(`` //[Binding]// ``)``
   |  |  **|**  | //Object// ``.`` //Attribute//
-  |  |  **|**  | ``Φ`` ``.`` //Attribute//
-  |  |  **|**  | ``ξ`` ``.`` //Attribute//
+  |  |  **|**  | ``Φ``
+  |  |  **|**  | ``ξ``
   |  |  **|**  | ``⊥``
   |  |  **|**  | //MetaId//
   | //Binding// | -> | //Attribute// ``↦`` //Object//

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Lex.x
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Lex.x
@@ -48,7 +48,7 @@ $c [$u # [\t \n \r \  \! \' \( \) \, \- \. \: \; \? \[ \] \{ \| \} \⟦ \⟧]] *
     { tok (eitherResIdent T_Function) }
 
 -- token LabelId
-$s [$u # [\t \n \r \  \! \' \( \) \, \- \. \: \; \? \[ \] \{ \| \} \⟦ \⟧]] *
+$s [$u # [\t \n \r \  \! \' \( \) \, \. \: \; \? \[ \] \{ \| \} \⟦ \⟧]] *
     { tok (eitherResIdent T_LabelId) }
 
 -- token AlphaIndex

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
@@ -93,8 +93,8 @@ Object
   : '⟦' ListBinding '⟧' { Language.EO.Phi.Syntax.Abs.Formation $2 }
   | Object '(' ListBinding ')' { Language.EO.Phi.Syntax.Abs.Application $1 $3 }
   | Object '.' Attribute { Language.EO.Phi.Syntax.Abs.ObjectDispatch $1 $3 }
-  | 'Φ' '.' Attribute { Language.EO.Phi.Syntax.Abs.GlobalDispatch $3 }
-  | 'ξ' '.' Attribute { Language.EO.Phi.Syntax.Abs.ThisDispatch $3 }
+  | 'Φ' { Language.EO.Phi.Syntax.Abs.GlobalObject }
+  | 'ξ' { Language.EO.Phi.Syntax.Abs.ThisObject }
   | '⊥' { Language.EO.Phi.Syntax.Abs.Termination }
   | MetaId { Language.EO.Phi.Syntax.Abs.MetaObject $1 }
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
@@ -156,8 +156,8 @@ instance Print Language.EO.Phi.Syntax.Abs.Object where
     Language.EO.Phi.Syntax.Abs.Formation bindings -> prPrec i 0 (concatD [doc (showString "\10214"), prt 0 bindings, doc (showString "\10215")])
     Language.EO.Phi.Syntax.Abs.Application object bindings -> prPrec i 0 (concatD [prt 0 object, doc (showString "("), prt 0 bindings, doc (showString ")")])
     Language.EO.Phi.Syntax.Abs.ObjectDispatch object attribute -> prPrec i 0 (concatD [prt 0 object, doc (showString "."), prt 0 attribute])
-    Language.EO.Phi.Syntax.Abs.GlobalDispatch attribute -> prPrec i 0 (concatD [doc (showString "\934"), doc (showString "."), prt 0 attribute])
-    Language.EO.Phi.Syntax.Abs.ThisDispatch attribute -> prPrec i 0 (concatD [doc (showString "\958"), doc (showString "."), prt 0 attribute])
+    Language.EO.Phi.Syntax.Abs.GlobalObject -> prPrec i 0 (concatD [doc (showString "\934")])
+    Language.EO.Phi.Syntax.Abs.ThisObject -> prPrec i 0 (concatD [doc (showString "\958")])
     Language.EO.Phi.Syntax.Abs.Termination -> prPrec i 0 (concatD [doc (showString "\8869")])
     Language.EO.Phi.Syntax.Abs.MetaObject metaid -> prPrec i 0 (concatD [prt 0 metaid])
 

--- a/eo-phi-normalizer/test/eo/phi/from-eo/as-phi.yaml
+++ b/eo-phi-normalizer/test/eo/phi/from-eo/as-phi.yaml
@@ -1,0 +1,9 @@
+title: Processing terms generated from EO
+tests:
+  - name: "A program that prints itself"
+    input: |
+      {org ↦ ⟦eolang ↦ ⟦prints-itself ↦ ⟦φ ↦ Φ.org.eolang.as-phi(α0 ↦ ξ).length.gt(α0 ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-00)))⟧, prints-itself-to-console ↦ ⟦x ↦ Φ.org.eolang.int(α0 ↦ Φ.org.eolang.bytes(Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout(α0 ↦ Φ.org.eolang.as-phi(α0 ↦ ξ))⟧, λ ⤍ Package⟧, λ ⤍ Package⟧}
+    normalized: |
+      { ν ↦ ⟦ Δ ⤍ 04- ⟧, org ↦ ⟦ ν ↦ ⟦ Δ ⤍ 03- ⟧, eolang ↦ ⟦ ν ↦ ⟦ Δ ⤍ 02- ⟧, prints-itself ↦ ⟦ ν ↦ ⟦ Δ ⤍ 00- ⟧, φ ↦ Φ.org.eolang.as-phi (α0 ↦ ξ).length.gt (α0 ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-00))) ⟧, prints-itself-to-console ↦ ⟦ ν ↦ ⟦ Δ ⤍ 01- ⟧, x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ)) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧ }
+    prettified: |
+      { org ↦ ⟦ eolang ↦ ⟦ prints-itself ↦ ⟦ φ ↦ Φ.org.eolang.as-phi (α0 ↦ ξ).length.gt (α0 ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-00))) ⟧, prints-itself-to-console ↦ ⟦ x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ)) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧ }


### PR DESCRIPTION
Closes #94.

- [x] Allow dash in labels.
- [x] Allow $\xi$ and $\Phi$ without dispatch.
- [x] Add test for the term that failed before.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR
This PR focuses on refactoring the object dispatch mechanism in the EO Phi language, replacing `GlobalDispatch` and `ThisDispatch` with `GlobalObject` and `ThisObject`.

### Detailed summary
- Replaced `GlobalDispatch` with `GlobalObject` in `Language.EO.Phi.Syntax.Abs.hs`
- Replaced `ThisDispatch` with `ThisObject` in `Language.EO.Phi.Syntax.Abs.hs`
- Updated corresponding functions and patterns in various files

> The following files were skipped due to too many changes: `eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->