### PR TITLE
Global object matching

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -52,8 +52,8 @@ main = do
         Left err -> error ("An error occurred parsing the input program: " <> err)
         Right input@(Program bindings) -> do
           let results
-                | chain = applyRulesChain (Context (convertRule <$> ruleSet.rules)) (Formation bindings)
-                | otherwise = pure <$> applyRules (Context (convertRule <$> ruleSet.rules)) (Formation bindings)
+                | chain = applyRulesChain (Context (convertRule <$> ruleSet.rules) []) (Formation bindings)
+                | otherwise = pure <$> applyRules (Context (convertRule <$> ruleSet.rules) []) (Formation bindings)
               uniqueResults = nub results
               totalResults = length uniqueResults
           logStrLn "Input:"

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -52,8 +53,8 @@ main = do
         Left err -> error ("An error occurred parsing the input program: " <> err)
         Right input@(Program bindings) -> do
           let results
-                | chain = applyRulesChain (Context (convertRule <$> ruleSet.rules) []) (Formation bindings)
-                | otherwise = pure <$> applyRules (Context (convertRule <$> ruleSet.rules) []) (Formation bindings)
+                | chain = applyRulesChain (Context (convertRule <$> ruleSet.rules) [Formation bindings]) (Formation bindings)
+                | otherwise = pure <$> applyRules (Context (convertRule <$> ruleSet.rules) [Formation bindings]) (Formation bindings)
               uniqueResults = nub results
               totalResults = length uniqueResults
           logStrLn "Input:"

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -5,6 +5,7 @@
 module Language.EO.Phi.Rules.Common where
 
 import Control.Applicative (Alternative ((<|>)), asum)
+import Data.List.NonEmpty (NonEmpty (..), (<|))
 import Data.String (IsString (..))
 import Language.EO.Phi.Syntax.Abs
 import Language.EO.Phi.Syntax.Lex (Token)
@@ -37,7 +38,7 @@ unsafeParseWith parser input =
 
 data Context = Context
   { allRules :: [Rule]
-  , outerFormations :: [Object]
+  , outerFormations :: NonEmpty Object
   }
 
 -- | A rule tries to apply a transformation to the root object, if possible.
@@ -53,7 +54,7 @@ applyOneRuleAtRoot ctx@Context{..} obj =
 extendContextWith :: Object -> Context -> Context
 extendContextWith obj ctx =
   ctx
-    { outerFormations = obj : outerFormations ctx
+    { outerFormations = obj <| outerFormations ctx
     }
 
 withSubObject :: (Context -> Object -> [Object]) -> Context -> Object -> [Object]

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -37,6 +37,7 @@ unsafeParseWith parser input =
 
 data Context = Context
   { allRules :: [Rule]
+  , outerFormations :: [Object]
   }
 
 -- | A rule tries to apply a transformation to the root object, if possible.
@@ -49,41 +50,47 @@ applyOneRuleAtRoot ctx@Context{..} obj =
   , obj' <- rule ctx obj
   ]
 
-withSubObject :: (Object -> [Object]) -> Object -> [Object]
-withSubObject f root =
-  f root
+extendContextWith :: Object -> Context -> Context
+extendContextWith obj ctx =
+  ctx
+    { outerFormations = obj : outerFormations ctx
+    }
+
+withSubObject :: (Context -> Object -> [Object]) -> Context -> Object -> [Object]
+withSubObject f ctx root =
+  f ctx root
     <|> case root of
       Formation bindings ->
-        Formation <$> withSubObjectBindings f bindings
+        Formation <$> withSubObjectBindings f (extendContextWith root ctx) bindings
       Application obj bindings ->
         asum
-          [ Application <$> withSubObject f obj <*> pure bindings
-          , Application obj <$> withSubObjectBindings f bindings
+          [ Application <$> withSubObject f ctx obj <*> pure bindings
+          , Application obj <$> withSubObjectBindings f ctx bindings
           ]
-      ObjectDispatch obj a -> ObjectDispatch <$> withSubObject f obj <*> pure a
+      ObjectDispatch obj a -> ObjectDispatch <$> withSubObject f ctx obj <*> pure a
       GlobalObject{} -> []
       ThisObject{} -> []
       Termination -> []
       MetaObject _ -> []
 
-withSubObjectBindings :: (Object -> [Object]) -> [Binding] -> [[Binding]]
-withSubObjectBindings _ [] = []
-withSubObjectBindings f (b : bs) =
+withSubObjectBindings :: (Context -> Object -> [Object]) -> Context -> [Binding] -> [[Binding]]
+withSubObjectBindings _ _ [] = []
+withSubObjectBindings f ctx (b : bs) =
   asum
-    [ [b' : bs | b' <- withSubObjectBinding f b]
-    , [b : bs' | bs' <- withSubObjectBindings f bs]
+    [ [b' : bs | b' <- withSubObjectBinding f ctx b]
+    , [b : bs' | bs' <- withSubObjectBindings f ctx bs]
     ]
 
-withSubObjectBinding :: (Object -> [Object]) -> Binding -> [Binding]
-withSubObjectBinding f = \case
-  AlphaBinding a obj -> AlphaBinding a <$> withSubObject f obj
+withSubObjectBinding :: (Context -> Object -> [Object]) -> Context -> Binding -> [Binding]
+withSubObjectBinding f ctx = \case
+  AlphaBinding a obj -> AlphaBinding a <$> withSubObject f ctx obj
   EmptyBinding{} -> []
   DeltaBinding{} -> []
   LambdaBinding{} -> []
   MetaBindings _ -> []
 
 applyOneRule :: Context -> Object -> [Object]
-applyOneRule = withSubObject . applyOneRuleAtRoot
+applyOneRule = withSubObject applyOneRuleAtRoot
 
 isNF :: Context -> Object -> Bool
 isNF ctx = null . applyOneRule ctx

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -12,6 +12,7 @@ module Language.EO.Phi.Rules.Yaml where
 import Data.Aeson (FromJSON (..), Options (sumEncoding), SumEncoding (UntaggedValue), genericParseJSON)
 import Data.Aeson.Types (defaultOptions)
 import Data.Coerce (coerce)
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (fromMaybe)
 import Data.String (IsString (..))
 import Data.Yaml qualified as Yaml
@@ -97,8 +98,8 @@ matchContext Common.Context{..} obj = \case
   Just (RuleContext Nothing (Just pattern)) -> matchObject pattern thisObject
   Just (RuleContext (Just globalPattern) (Just thisPattern)) -> matchObject globalPattern globalObject ++ matchObject thisPattern thisObject
  where
-  globalObject = last outerFormations
-  thisObject = head outerFormations
+  globalObject = NonEmpty.last outerFormations
+  thisObject = NonEmpty.head outerFormations
 
 objectHasMetavars :: Object -> Bool
 objectHasMetavars (Formation bindings) = any bindingHasMetavars bindings

--- a/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -34,7 +35,7 @@ spec = do
           forM_ tests $
             \PhiTest{..} ->
               it name $
-                applyRule (rule (Context [] [])) input `shouldBe` [normalized]
+                applyRule (rule (Context [] [progToObj input])) input `shouldBe` [normalized]
   describe "Programs translated from EO" $ do
     phiTests <- runIO (allPhiTests "test/eo/phi/from-eo/")
     forM_ phiTests $ \PhiTestGroup{..} ->
@@ -50,3 +51,6 @@ spec = do
 
 trim :: String -> String
 trim = dropWhileEnd isSpace
+
+progToObj :: Program -> Object
+progToObj (Program bindings) = Formation bindings

--- a/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
@@ -34,7 +34,7 @@ spec = do
           forM_ tests $
             \PhiTest{..} ->
               it name $
-                applyRule (rule (Context [])) input `shouldBe` [normalized]
+                applyRule (rule (Context [] [])) input `shouldBe` [normalized]
   describe "Programs translated from EO" $ do
     phiTests <- runIO (allPhiTests "test/eo/phi/from-eo/")
     forM_ phiTests $ \PhiTestGroup{..} ->

--- a/eo-phi-normalizer/test/Language/EO/YamlSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/YamlSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 
 module Language.EO.YamlSpec where
@@ -17,4 +18,4 @@ spec = describe "User-defined rules unit tests" do
       describe rule.name do
         forM_ rule.tests $ \ruleTest -> do
           it ruleTest.name $
-            convertRule rule (Context [] []) ruleTest.input `shouldBe` [ruleTest.output | ruleTest.matches]
+            convertRule rule (Context [] [ruleTest.input]) ruleTest.input `shouldBe` [ruleTest.output | ruleTest.matches]

--- a/eo-phi-normalizer/test/Language/EO/YamlSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/YamlSpec.hs
@@ -17,4 +17,4 @@ spec = describe "User-defined rules unit tests" do
       describe rule.name do
         forM_ rule.tests $ \ruleTest -> do
           it ruleTest.name $
-            convertRule rule (Context []) ruleTest.input `shouldBe` [ruleTest.output | ruleTest.matches]
+            convertRule rule (Context [] []) ruleTest.input `shouldBe` [ruleTest.output | ruleTest.matches]

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -27,6 +27,21 @@ rules:
         output: '⟦ a ↦ ⟦ b ↦ ⟦ ⟧ ⟧ ⟧'
         matches: false
 
+  - name: Rule 4
+    description: 'Φ-dispatch'
+    context:
+      global_object: ⟦ !B ⟧
+    pattern: |
+      Φ.!a
+    result: |
+      ⟦ σ ↦ Φ, !B ⟧.!a
+    when: []
+    tests:
+      - name: Should match
+        input: Φ.a
+        output: ⟦ σ ↦ Φ ⟧.a
+        matches: true
+
   - name: Rule 5
     description: "ξ-dispatch"
     pattern: |

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -36,18 +36,16 @@ rules:
     result: |
       ⟦ σ ↦ Φ, !B ⟧.!a
     when: []
-    tests:
-      - name: Should match
-        input: Φ.a
-        output: ⟦ σ ↦ Φ ⟧.a
-        matches: true
+    tests: []
 
   - name: Rule 5
     description: "ξ-dispatch"
+    context:
+      current_object: ⟦ !a ↦ ξ.!b, !B ⟧
     pattern: |
-      ⟦ !a ↦ ξ.!b, !B ⟧
+      ξ
     result: |
-      ⟦ !a ↦ ⟦ !B ⟧.!b, !B ⟧
+      ⟦ !B ⟧
     when: []
     tests: []
 


### PR DESCRIPTION
Adds context to a rule that specifies if global object (`Φ`) or current object (`ξ`) should be matched and substitutes immediately in pattern and result.

Closes #57

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR introduces new rules and updates existing code in the EO Phi Normalizer.

### Detailed summary:
- Added a new rule named "Rule 4" with a Φ-dispatch pattern and result.
- Updated the description and context of "Rule 4".
- Removed "Rule 5" and its description.
- Updated the context and pattern of "Rule 5".
- Added a new rule context type named "RuleContext".
- Updated the `convertRule` function to handle rule contexts.
- Added a new function `matchContext` to match rule contexts.
- Added a new function `extendContextWith` to extend the context with an object.
- Updated the `withSubObject` function to include the context.
- Updated the `withSubObjectBindings` function to include the context.
- Updated the `withSubObjectBinding` function to include the context.
- Added a new function `progToObj` to convert a program to an object.
- Updated the `convertRule` function to use `progToObj`.
- Added imports and language extensions as needed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->