### PR TITLE
101 print a single normalized program when passed user defined rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ Result 1 out of 1:
 ----------------------------------------------------
 ```
 
+#### `--single`
+
+Use `--single` to print a single normalized program.
+
+```sh
+# Command
+stack run -- --single --rules-yaml ./eo-phi-normalizer/test/eo/phi/rules/yegor.yaml test.phi
+
+# Output
+⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧
+```
+
 ## Rulesets
 
 A ruleset describes a set of user-defined rewriting rules.

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -8,13 +8,13 @@
 
 module Main where
 
-import Control.Monad (when)
+import Control.Monad (unless, when)
 import Data.Foldable (forM_)
 
 import Data.List (nub)
 import Language.EO.Phi (Object (Formation), Program (Program), defaultMain, parseProgram, printTree)
 import Language.EO.Phi.Rules.Common (Context (..), applyRules, applyRulesChain)
-import Language.EO.Phi.Rules.Yaml
+import Language.EO.Phi.Rules.Yaml (RuleSet (rules, title), convertRule, parseRuleSetFromFile)
 import Options.Generic
 import System.IO (IOMode (WriteMode), hClose, hPutStr, hPutStrLn, openFile, stdout)
 
@@ -22,6 +22,7 @@ data CLINamedParams = CLINamedParams
   { chain :: Bool
   , rulesYaml :: Maybe String
   , outPath :: Maybe String
+  , single :: Bool
   }
   deriving (Generic, Show, ParseRecord, Read, ParseField)
 
@@ -31,6 +32,7 @@ instance ParseFields CLINamedParams where
       <$> parseFields (Just "Print out steps of reduction") (Just "chain") (Just 'c') Nothing
       <*> parseFields (Just "Path to the Yaml file with custom rules") (Just "rules-yaml") Nothing Nothing
       <*> parseFields (Just "Output file path (defaults to stdout)") (Just "output") (Just 'o') Nothing
+      <*> parseFields (Just "Print a single normlized expression") (Just "single") (Just 's') Nothing
 
 data CLIOptions = CLIOptions CLINamedParams (Maybe FilePath)
   deriving (Generic, Show, ParseRecord)
@@ -46,7 +48,7 @@ main = do
       let logStr = hPutStr handle
       let logStrLn = hPutStrLn handle
       ruleSet <- parseRuleSetFromFile path
-      logStrLn ruleSet.title
+      unless single $ logStrLn ruleSet.title
       src <- maybe getContents readFile inPath
       let progOrError = parseProgram src
       case progOrError of
@@ -57,18 +59,22 @@ main = do
                 | otherwise = pure <$> applyRules (Context (convertRule <$> ruleSet.rules) [Formation bindings]) (Formation bindings)
               uniqueResults = nub results
               totalResults = length uniqueResults
-          logStrLn "Input:"
-          logStrLn (printTree input)
-          logStrLn "===================================================="
-          forM_ (zip [1 ..] uniqueResults) $ \(i, steps) -> do
-            logStrLn $
-              "Result " <> show i <> " out of " <> show totalResults <> ":"
-            let n = length steps
-            forM_ (zip [1 ..] steps) $ \(k, step) -> do
-              Control.Monad.when chain $
-                logStr ("[ " <> show k <> " / " <> show n <> " ]")
-              logStrLn (printTree step)
-            logStrLn "----------------------------------------------------"
+          when (totalResults == 0) $ error "Could not normalize the program"
+          if single
+            then logStrLn (printTree (head uniqueResults))
+            else do
+              logStrLn "Input:"
+              logStrLn (printTree input)
+              logStrLn "===================================================="
+              forM_ (zip [1 ..] uniqueResults) $ \(i, steps) -> do
+                logStrLn $
+                  "Result " <> show i <> " out of " <> show totalResults <> ":"
+                let n = length steps
+                forM_ (zip [1 ..] steps) $ \(k, step) -> do
+                  when chain $
+                    logStr ("[ " <> show k <> " / " <> show n <> " ]")
+                  logStrLn (printTree step)
+                logStrLn "----------------------------------------------------"
       hClose handle
     -- TODO #48:15m still need to consider `chain` (should rewrite/change defaultMain to mainWithOptions)
     Nothing -> defaultMain


### PR DESCRIPTION
Closes #101

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new command-line option `--single` to print a single normalized program.
- Modified the behavior of printing the rule set title to only print it when `--single` is not specified.
- Updated the main function to handle the new `--single` option and print the single normalized program if specified.
- Added error handling for cases where the program cannot be normalized.
- Updated the output format to include step numbers when `--chain` is specified.
- Added new user instructions to the README.md file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->