### PR TITLE
Add rule 12 to the user-defined rules

### DIFF
--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -240,6 +240,7 @@ matchObject (MetaObject m) obj =
       , bindingsMetas = []
       , attributeMetas = []
       }
+matchObject Termination Termination = [emptySubst]
 matchObject _ _ = [] -- ? emptySubst ?
 
 matchBindings :: [Binding] -> [Binding] -> [Subst]

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -136,3 +136,20 @@ rules:
         input: '⟦ ρ ↦ ⟦ ⟧, σ ↦ ⟦ ⟧ ⟧.x'
         output: '⊥'
         matches: true
+
+  - name: Rule 12
+    description: 'Accessing an attribute on bottom'
+    pattern: |
+      ⊥.!a
+    result: |
+      ⊥
+    when: []
+    tests:
+      - name: 'Dispatch on bottom is bottom'
+        input: '⊥.a'
+        output: '⊥'
+        matches: true
+      - name: 'Dispatch on anything else is not touched'
+        input: '⟦ ⟧.a'
+        output: '⟦ ⟧.a'
+        matches: false


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a new rule in the EO Phi normalizer. 

### Detailed summary
- Added a new rule `Rule 12` in `eo-phi-normalizer/test/eo/phi/rules/yegor.yaml`.
- The new rule handles the case of accessing an attribute on bottom (`⊥`).
- The rule pattern is `⊥.!a` and the result is `⊥`.
- Included tests to ensure the correctness of the rule.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->