### PR TITLE
Add rule 2 to user-defined rules

### DIFF
--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -19,6 +19,26 @@ rules:
         output: '⟦ a ↦ ⟦ ν ↦ ⟦ Δ ⤍ 00- ⟧ ⟧ ⟧'
         matches: true
 
+  - name: Rule 2
+    description: ''
+    pattern: |
+      ⟦ !a ↦ ⟦ !b ↦ ⟦ !B1 ⟧, σ ↦ !obj, !B2 ⟧, !B_rest ⟧
+    result: |
+      ⟦ !a ↦ ⟦ !b ↦ ⟦ σ ↦ !obj.!a, !B1 ⟧, σ ↦ !obj, !B2 ⟧, !B_rest ⟧
+    when:
+      - absent_attrs:
+          attrs: ['σ']
+          bindings: ['!B1']
+    tests:
+      - name: 'Adds home attribute'
+        input: '⟦ a ↦ ⟦ b ↦ ⟦ ⟧, σ ↦ ⟦ ⟧ ⟧ ⟧'
+        output: '⟦ a ↦ ⟦ b ↦ ⟦ σ ↦ ⟦ ⟧.a ⟧, σ ↦ ⟦ ⟧ ⟧ ⟧'
+        matches: true
+      - name: 'Leaves the object unchanged'
+        input: '⟦ a ↦ ⟦ b ↦ ⟦ σ ↦ ⟦ ⟧ ⟧ ⟧ ⟧'
+        output: '⟦ a ↦ ⟦ b ↦ ⟦ σ ↦ ⟦ ⟧ ⟧ ⟧ ⟧'
+        matches: false
+
   - name: Rule 3
     description: 'Initialization of parent attribute'
     pattern: |


### PR DESCRIPTION
The base branch is set to `rule-global-counter` just to display the actual diff while avoiding merge conflicts. #105 should be merged before this one.

<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Added a new rule named "Rule 2" to the `yegor.yaml` file in the `eo-phi-normalizer` module.
- The new rule adds a home attribute to the object if it is absent.
- The rule modifies the pattern and result of the object.
- Two tests were added to validate the behavior of the rule.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->