### PR TITLE
79 collect optimization metrics

### DIFF
--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -106,6 +106,7 @@ test-suite eo-phi-normalizer-test
       Language.EO.YamlSpec
       Test.EO.Phi
       Test.EO.Yaml
+      Test.Metrics.Phi
       Paths_eo_phi_normalizer
   hs-source-dirs:
       test

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -34,6 +34,7 @@ custom-setup
 library
   exposed-modules:
       Language.EO.Phi
+      Language.EO.Phi.Metrics.Collect
       Language.EO.Phi.Normalize
       Language.EO.Phi.Rules.Common
       Language.EO.Phi.Rules.PhiPaper
@@ -61,6 +62,8 @@ library
     , base >=4.7 && <5
     , directory
     , filepath
+    , generic-lens
+    , lens
     , mtl
     , string-interpolate
     , yaml
@@ -87,6 +90,8 @@ executable normalize-phi
     , directory
     , eo-phi-normalizer
     , filepath
+    , generic-lens
+    , lens
     , mtl
     , optparse-generic
     , string-interpolate
@@ -119,8 +124,10 @@ test-suite eo-phi-normalizer-test
     , directory
     , eo-phi-normalizer
     , filepath
+    , generic-lens
     , hspec
     , hspec-discover
+    , lens
     , mtl
     , string-interpolate
     , yaml

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -44,6 +44,8 @@ dependencies:
   - yaml
   - mtl
   - string-interpolate
+  - lens
+  - generic-lens
 
 default-extensions:
   - ImportQualifiedPost

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
@@ -16,68 +16,68 @@ import Language.EO.Phi.Rules.Common ()
 import Language.EO.Phi.Syntax.Abs
 
 data Metrics = Metrics
-    { dataless :: Int
-    , applications :: Int
-    , formations :: Int
-    , dispatches :: Int
-    }
-    deriving (Generic, Show, FromJSON, Eq)
+  { dataless :: Int
+  , applications :: Int
+  , formations :: Int
+  , dispatches :: Int
+  }
+  deriving (Generic, Show, FromJSON, Eq)
 
 defaultMetrics :: Metrics
 defaultMetrics =
-    Metrics
-        { dataless = 0
-        , applications = 0
-        , formations = 0
-        , dispatches = 0
-        }
+  Metrics
+    { dataless = 0
+    , applications = 0
+    , formations = 0
+    , dispatches = 0
+    }
 
 collectMetrics :: (Inspectable a) => a -> Metrics
 collectMetrics a = execState (inspect a) defaultMetrics
 
 class Inspectable a where
-    inspect :: a -> State Metrics ()
+  inspect :: a -> State Metrics ()
 
 instance Inspectable Program where
-    inspect (Program binding) = forM_ binding inspect
+  inspect (Program binding) = forM_ binding inspect
 
 instance Inspectable Binding where
-    inspect = \case
-        AlphaBinding attr obj -> do
-            inspect attr
-            inspect obj
-        EmptyBinding attr -> do
-            #dataless += 1
-            inspect attr
-        DeltaBinding _ -> pure ()
-        LambdaBinding _ -> #dataless += 1
-        MetaBindings _ -> pure ()
+  inspect = \case
+    AlphaBinding attr obj -> do
+      inspect attr
+      inspect obj
+    EmptyBinding attr -> do
+      #dataless += 1
+      inspect attr
+    DeltaBinding _ -> pure ()
+    LambdaBinding _ -> #dataless += 1
+    MetaBindings _ -> pure ()
 
 instance Inspectable Attribute where
-    inspect = \case
-        Phi -> pure ()
-        Rho -> pure ()
-        Sigma -> pure ()
-        VTX -> pure ()
-        Label _ -> pure ()
-        Alpha _ -> pure ()
-        MetaAttr _ -> pure ()
+  inspect = \case
+    Phi -> pure ()
+    Rho -> pure ()
+    Sigma -> pure ()
+    VTX -> pure ()
+    Label _ -> pure ()
+    Alpha _ -> pure ()
+    MetaAttr _ -> pure ()
 
 instance Inspectable Object where
-    inspect = \case
-        Formation bindings -> do
-            #formations += 1
-            forM_ bindings inspect
-        Application obj bindings -> do
-            #applications += 1
-            inspect obj
-            forM_ bindings inspect
-        ObjectDispatch obj attr -> do
-            #dispatches += 1
-            inspect obj
-            inspect attr
-        GlobalObject -> pure ()
-        ThisObject -> pure ()
-        Termination -> pure ()
-        MetaObject _ -> pure ()
-        MetaFunction _ _ -> pure ()
+  inspect = \case
+    Formation bindings -> do
+      #formations += 1
+      forM_ bindings inspect
+    Application obj bindings -> do
+      #applications += 1
+      inspect obj
+      forM_ bindings inspect
+    ObjectDispatch obj attr -> do
+      #dispatches += 1
+      inspect obj
+      inspect attr
+    GlobalObject -> pure ()
+    ThisObject -> pure ()
+    Termination -> pure ()
+    MetaObject _ -> pure ()
+    MetaFunction _ _ -> pure ()

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedLabels #-}
+
+module Language.EO.Phi.Metrics.Collect where
+
+import Control.Lens ((+=))
+import Control.Monad (forM_)
+import Control.Monad.State (MonadState)
+import Data.Generics.Labels ()
+import GHC.Generics (Generic)
+import Language.EO.Phi.Syntax.Abs
+
+data Metrics = Metrics
+    { dataless :: Int
+    , applications :: Int
+    , formations :: Int
+    , dispatches :: Int
+    }
+    deriving (Generic)
+
+class Inspectable a where
+    inspect :: (MonadState Metrics m) => a -> m ()
+
+instance Inspectable Program where
+    inspect (Program binding) = forM_ binding inspect
+
+instance Inspectable Binding where
+    inspect = \case
+        AlphaBinding attr obj -> do
+            inspect attr
+            inspect obj
+        EmptyBinding attr -> do
+            #dataless += 1
+            inspect attr
+        DeltaBinding _ -> pure ()
+        LambdaBinding _ -> #dataless += 1
+        MetaBindings _ -> pure ()
+
+instance Inspectable Attribute where
+    inspect = \case
+        Phi -> pure ()
+        Rho -> pure ()
+        Sigma -> pure ()
+        VTX -> pure ()
+        Label _ -> pure ()
+        Alpha _ -> pure ()
+        MetaAttr _ -> pure ()
+
+instance Inspectable Object where
+    inspect = \case
+        Formation bindings -> do
+            #formations += 1
+            forM_ bindings inspect
+        Application obj bindings -> do
+            #applications += 1
+            inspect obj
+            forM_ bindings inspect
+        ObjectDispatch obj attr -> do
+            #dispatches += 1
+            inspect obj
+            inspect attr
+        GlobalObject -> pure ()
+        ThisObject -> pure ()
+        Termination -> pure ()
+        MetaObject _ -> pure ()
+        MetaFunction _ _ -> pure ()

--- a/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Language.EO.PhiSpec where
@@ -11,12 +12,16 @@ module Language.EO.PhiSpec where
 import Control.Monad (forM_)
 import Data.Char (isSpace)
 import Data.List (dropWhileEnd)
+import Data.String (IsString (..))
 import Data.String.Interpolate (i)
+import Data.Yaml (decodeFileThrow)
 import Language.EO.Phi
+import Language.EO.Phi.Metrics.Collect (collectMetrics)
 import Language.EO.Phi.Rules.Common (Context (..), Rule)
 import Language.EO.Phi.Rules.PhiPaper (rule1, rule6)
 import Test.EO.Phi
 import Test.Hspec
+import Test.Metrics.Phi (MetricsTest (..), MetricsTestSet (..))
 
 applyRule :: (Object -> [Object]) -> Program -> [Program]
 applyRule rule = \case
@@ -48,6 +53,11 @@ spec = do
             describe "pretty-print" $
               it name $
                 printTree input `shouldBe` trim prettified
+  describe "Metrics" $ do
+    metricsTests <- runIO $ decodeFileThrow @_ @MetricsTestSet "test/eo/phi/metrics.yaml"
+    forM_ metricsTests.tests $ \test -> do
+      it test.title $
+        collectMetrics (fromString @Program test.phi) `shouldBe` test.metrics
 
 trim :: String -> String
 trim = dropWhileEnd isSpace

--- a/eo-phi-normalizer/test/Test/Metrics/Phi.hs
+++ b/eo-phi-normalizer/test/Test/Metrics/Phi.hs
@@ -9,14 +9,14 @@ import GHC.Generics (Generic)
 import Language.EO.Phi.Metrics.Collect (Metrics)
 
 data MetricsTestSet = MetricsTestSet
-    { title :: String
-    , tests :: [MetricsTest]
-    }
-    deriving (Generic, FromJSON)
+  { title :: String
+  , tests :: [MetricsTest]
+  }
+  deriving (Generic, FromJSON)
 
 data MetricsTest = MetricsTest
-    { title :: String
-    , phi :: String
-    , metrics :: Metrics
-    }
-    deriving (Generic, FromJSON)
+  { title :: String
+  , phi :: String
+  , metrics :: Metrics
+  }
+  deriving (Generic, FromJSON)

--- a/eo-phi-normalizer/test/Test/Metrics/Phi.hs
+++ b/eo-phi-normalizer/test/Test/Metrics/Phi.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Test.Metrics.Phi where
+
+import Data.Yaml (FromJSON)
+import GHC.Generics (Generic)
+import Language.EO.Phi.Metrics.Collect (Metrics)
+
+data MetricsTestSet = MetricsTestSet
+    { title :: String
+    , tests :: [MetricsTest]
+    }
+    deriving (Generic, FromJSON)
+
+data MetricsTest = MetricsTest
+    { title :: String
+    , phi :: String
+    , metrics :: Metrics
+    }
+    deriving (Generic, FromJSON)

--- a/eo-phi-normalizer/test/eo/phi/metrics.yaml
+++ b/eo-phi-normalizer/test/eo/phi/metrics.yaml
@@ -1,0 +1,41 @@
+title: Metrics tests
+tests:
+- title: prints-itself
+  phi: |
+    {
+      org ↦ ⟦
+        eolang ↦ ⟦
+          prints-itself ↦ ⟦
+            φ ↦
+              Φ.org.eolang.as-phi(
+                α0 ↦ ξ
+              ).length.gt(
+                α0 ↦ Φ.org.eolang.int(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-00-00-00-00-00-00-00
+                  )
+                )
+              )
+          ⟧,
+          prints-itself-to-console ↦ ⟦
+            x ↦ Φ.org.eolang.int(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-00-00-00-00-00-00-2A
+              )
+            ),
+            φ ↦ Φ.org.eolang.io.stdout(
+              α0 ↦ Φ.org.eolang.as-phi(
+                α0 ↦ ξ
+              )
+            )
+          ⟧,
+          λ ⤍ Package
+        ⟧,
+        λ ⤍ Package
+      ⟧
+    }
+  metrics:
+    dataless: 2
+    applications: 8
+    formations: 4
+    dispatches: 24


### PR DESCRIPTION
Closes #79

- How to count dataless attributes?

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding metrics collection functionality to the `eo-phi-normalizer` package.

### Detailed summary:
- Added `MetricsTestSet` and `MetricsTest` data types to represent metrics tests.
- Added `Metrics` data type to represent various metrics.
- Added `collectMetrics` function to collect metrics from a given program.
- Added `Inspectable` type class and instances for `Program`, `Binding`, `Attribute`, and `Object` to enable metrics collection.
- Updated `Test.Metrics.Phi` module to include tests for metrics collection.
- Modified `eo-phi-normalizer.cabal` to include `generic-lens` and `lens` as dependencies.
- Modified `eo-phi-normalizer-test` to include `Test.Metrics.Phi` as a test module.
- Added `Metrics` module to `eo-phi-normalizer` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->