### PR TITLE
fix: print program

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -32,7 +32,7 @@ instance ParseFields CLINamedParams where
       <$> parseFields (Just "Print out steps of reduction") (Just "chain") (Just 'c') Nothing
       <*> parseFields (Just "Path to the Yaml file with custom rules") (Just "rules-yaml") Nothing Nothing
       <*> parseFields (Just "Output file path (defaults to stdout)") (Just "output") (Just 'o') Nothing
-      <*> parseFields (Just "Print a single normlized expression") (Just "single") (Just 's') Nothing
+      <*> parseFields (Just "Print a single normalized expression") (Just "single") (Just 's') Nothing
 
 data CLIOptions = CLIOptions CLINamedParams (Maybe FilePath)
   deriving (Generic, Show, ParseRecord)

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -59,9 +59,12 @@ main = do
                 | otherwise = pure <$> applyRules (Context (convertRule <$> ruleSet.rules) [Formation bindings]) (Formation bindings)
               uniqueResults = nub results
               totalResults = length uniqueResults
-          when (totalResults == 0) $ error "Could not normalize the program"
+          when (length uniqueResults == 0 || length (head uniqueResults) == 0) $ error "Could not normalize the program"
           if single
-            then logStrLn (printTree (head uniqueResults))
+            then logStrLn $
+              case head (head uniqueResults) of
+                Formation bindings' -> printTree $ Program bindings'
+                _ -> printTree (head uniqueResults)
             else do
               logStrLn "Input:"
               logStrLn (printTree input)
@@ -73,7 +76,10 @@ main = do
                 forM_ (zip [1 ..] steps) $ \(k, step) -> do
                   when chain $
                     logStr ("[ " <> show k <> " / " <> show n <> " ]")
-                  logStrLn (printTree step)
+                  logStrLn $
+                    case step of
+                      Formation bindings' -> printTree $ Program bindings'
+                      _ -> printTree step
                 logStrLn "----------------------------------------------------"
       hClose handle
     -- TODO #48:15m still need to consider `chain` (should rewrite/change defaultMain to mainWithOptions)


### PR DESCRIPTION
Closes #108 and fixes printing without a `--single` flag.

```
stack run -- --single --rules-yaml ./eo-phi-normalizer/test/eo/phi/rules/yegor.yaml program.phi
```

before:

```
⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧
```

after:

```
{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ d ↦ ⟦ φ ↦ ξ.ρ.c, ν ↦ ⟦ Δ ⤍ 00- ⟧ ⟧, c ↦ ∅, ν ↦ ⟦ Δ ⤍ 00- ⟧ ⟧ ⟧) ⟧ }
```

------

```
stack run -- --rules-yaml ./eo-phi-normalizer/test/eo/phi/rules/yegor.yaml program.phi
```

before:

```
Rule set based on Yegor's draft
Input:
{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧.e ⟧ }
====================================================
Result 1 out of 1:
⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ d ↦ ⟦ φ ↦ ξ.ρ.c, ν ↦ ⟦ Δ ⤍ 00- ⟧ ⟧, c ↦ ∅, ν ↦ ⟦ Δ ⤍ 00- ⟧ ⟧ ⟧) ⟧
----------------------------------------------------
```

after:

```
Rule set based on Yegor's draft
Input:
{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧.e ⟧ }
====================================================
Result 1 out of 1:
{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ d ↦ ⟦ φ ↦ ξ.ρ.c, ν ↦ ⟦ Δ ⤍ 00- ⟧ ⟧, c ↦ ∅, ν ↦ ⟦ Δ ⤍ 00- ⟧ ⟧ ⟧) ⟧ }
----------------------------------------------------
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the CLI help message and refactors the printing logic in `Main.hs`.

### Detailed summary
- Updated CLI help message for a better description
- Refactored printing logic for single normalized expression output
- Improved error handling for empty results
- Refactored printing logic for steps in the main function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->