### PR TITLE
138 fix the metric for dataless formations

### DIFF
--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
@@ -48,9 +48,7 @@ countDataless bindings = do
   when (deltas == 0) (#dataless += 1)
 
 instance Inspectable Program where
-  inspect (Program bindings) = do
-    countDataless bindings
-    forM_ bindings inspect
+  inspect (Program bindings) = inspect (Formation bindings)
 
 instance Inspectable Binding where
   inspect = \case

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
@@ -59,19 +59,10 @@ instance Inspectable Binding where
       inspect obj
     EmptyBinding attr -> do
       inspect attr
-    DeltaBinding _ -> pure ()
-    LambdaBinding _ -> pure ()
-    MetaBindings _ -> pure ()
+    _ -> pure ()
 
 instance Inspectable Attribute where
-  inspect = \case
-    Phi -> pure ()
-    Rho -> pure ()
-    Sigma -> pure ()
-    VTX -> pure ()
-    Label _ -> pure ()
-    Alpha _ -> pure ()
-    MetaAttr _ -> pure ()
+  inspect _ = pure ()
 
 instance Inspectable Object where
   inspect = \case
@@ -87,8 +78,4 @@ instance Inspectable Object where
       #dispatches += 1
       inspect obj
       inspect attr
-    GlobalObject -> pure ()
-    ThisObject -> pure ()
-    Termination -> pure ()
-    MetaObject _ -> pure ()
-    MetaFunction _ _ -> pure ()
+    _ -> pure ()

--- a/eo-phi-normalizer/test/eo/phi/metrics.yaml
+++ b/eo-phi-normalizer/test/eo/phi/metrics.yaml
@@ -2,7 +2,8 @@ title: Metrics tests
 tests:
 - title: prints-itself
   phi: |
-    { ⟦
+    {
+      ⟦
         org ↦ ⟦
           eolang ↦ ⟦
             prints-itself ↦ ⟦
@@ -38,5 +39,5 @@ tests:
   metrics:
     dataless: 5
     applications: 8
-    formations: 4
+    formations: 5
     dispatches: 24

--- a/eo-phi-normalizer/test/eo/phi/metrics.yaml
+++ b/eo-phi-normalizer/test/eo/phi/metrics.yaml
@@ -36,7 +36,7 @@ tests:
       ⟧
     }
   metrics:
-    dataless: 2
+    dataless: 5
     applications: 8
     formations: 4
     dispatches: 24


### PR DESCRIPTION
Closes #138

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `eo-phi-normalizer` by improving metrics calculation and adding a new function for counting dataless formations.

### Detailed summary
- Increased `dataless` metric values in `metrics.yaml`
- Added a new function `countDataless` to count dataless formations in bindings
- Updated the inspection logic in `Collect.hs` to utilize the new function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->