### PR TITLE
fix: downgrade resolver

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-22.11
+resolver: lts-22.6
 packages:
 - eo-phi-normalizer

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 2fdd7d3e54540062ef75ca0a73ca3a804c527dbf8a4cadafabf340e66ac4af40
-    size: 712469
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/11.yaml
-  original: lts-22.11
+    sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575
+    size: 714100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/6.yaml
+  original: lts-22.6


### PR DESCRIPTION
Closes #145 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the resolver in `stack.yaml` and the snapshot details in `stack.yaml.lock` to use `lts-22.6`.

### Detailed summary
- Updated resolver to `lts-22.6` in `stack.yaml`
- Updated snapshot details in `stack.yaml.lock` to use `lts-22.6`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->