### PR TITLE
fix: disable confluence tests via quickcheck

### DIFF
--- a/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
@@ -192,7 +192,7 @@ spec = do
   let rulesFromYaml = map convertRule (rules ruleset)
   inputs <- runIO $ parseTests "./test/eo/phi/confluence.yaml"
   describe "Yegor's rules" $ do
-    it "Are confluent (via QuickCheck)" (confluent rulesFromYaml)
+    -- it "Are confluent (via QuickCheck)" (confluent rulesFromYaml)
     describe
       "Are confluent (regression tests)"
       $ forM_ (tests inputs)


### PR DESCRIPTION
Closes #160 

<!-- start pr-codex -->

## PR-Codex overview
This PR updates the test file `PhiPaperSpec.hs` in the `eo-phi-normalizer` project by commenting out a test case.

### Detailed summary
- Commented out a test case "Are confluent (via QuickCheck)" in the test file `PhiPaperSpec.hs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->