### PR TITLE
Add support for Delta bindings with no value

### DIFF
--- a/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
+++ b/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
@@ -25,11 +25,12 @@ Termination.    Object ::= "⊥" ;
 MetaObject.     Object ::= MetaId ;
 MetaFunction.   Object ::= MetaFunctionName "(" Object ")" ;
 
-AlphaBinding.   Binding ::= Attribute "↦" Object ;
-EmptyBinding.   Binding ::= Attribute "↦" "∅" ;
-DeltaBinding.   Binding ::= "Δ" "⤍" Bytes ;
-LambdaBinding.  Binding ::= "λ" "⤍" Function ;
-MetaBindings.   Binding ::= MetaId ;
+AlphaBinding.       Binding ::= Attribute "↦" Object ;
+EmptyBinding.       Binding ::= Attribute "↦" "∅" ;
+DeltaBinding.       Binding ::= "Δ" "⤍" Bytes ;
+DeltaEmptyBinding.  Binding ::= "Δ" "⤍" "∅" ;
+LambdaBinding.      Binding ::= "λ" "⤍" Function ;
+MetaBindings.       Binding ::= MetaId ;
 separator Binding "," ;
 
 Phi.    Attribute ::= "φ" ;   -- decoratee object

--- a/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
+++ b/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
@@ -4,6 +4,9 @@
 --
 -- This is a non-ambiguous grammar for φ-programs.
 
+comment "//" ;
+comment "/*" "*/" ;
+
 token Bytes ({"--"} | ["0123456789ABCDEF"] ["0123456789ABCDEF"] {"-"} | ["0123456789ABCDEF"] ["0123456789ABCDEF"] ({"-"} ["0123456789ABCDEF"] ["0123456789ABCDEF"])+) ;
 token Function upper (char - [" \r\n\t,.|':;!-?][}{)(⟧⟦"])* ;
 token LabelId  lower (char - [" \r\n\t,.|':;!?][}{)(⟧⟦"])* ;

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics/Collect.hs
@@ -68,7 +68,7 @@ count x = length . filter x
 -- 1
 countDataless :: (Num a) => [Binding] -> a
 countDataless bindings =
-  let countDeltas = count (\case DeltaBinding _ -> True; _ -> False)
+  let countDeltas = count (\case DeltaBinding _ -> True; DeltaEmptyBinding -> True; _ -> False)
       nestedBindings = concatMap (\case AlphaBinding _ (Formation bindings') -> bindings'; _ -> []) bindings
       deltas = countDeltas (bindings <> nestedBindings)
    in if deltas == 0 then 1 else 0

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -96,6 +96,7 @@ withSubObjectBinding f ctx = \case
   AlphaBinding a obj -> AlphaBinding a <$> withSubObject f (ctx{currentAttr = a}) obj
   EmptyBinding{} -> []
   DeltaBinding{} -> []
+  DeltaEmptyBinding{} -> []
   LambdaBinding{} -> []
   MetaBindings _ -> []
 
@@ -139,6 +140,7 @@ bindingSize = \case
   AlphaBinding _attr obj -> objectSize obj
   EmptyBinding _attr -> 1
   DeltaBinding _bytes -> 1
+  DeltaEmptyBinding -> 1
   LambdaBinding _lam -> 1
   MetaBindings{} -> 1 -- should be impossible
 
@@ -174,6 +176,7 @@ equalBindings bindings1 bindings2 = and (zipWith equalBinding (sortOn attr bindi
   attr (AlphaBinding a _) = a
   attr (EmptyBinding a) = a
   attr (DeltaBinding _) = Label (LabelId "Δ")
+  attr DeltaEmptyBinding = Label (LabelId "Δ")
   attr (LambdaBinding _) = Label (LabelId "λ")
   attr (MetaBindings metaId) = MetaAttr metaId
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -131,6 +131,7 @@ bindingHasMetavars :: Binding -> Bool
 bindingHasMetavars (AlphaBinding attr obj) = attrHasMetavars attr || objectHasMetavars obj
 bindingHasMetavars (EmptyBinding attr) = attrHasMetavars attr
 bindingHasMetavars (DeltaBinding _) = False
+bindingHasMetavars DeltaEmptyBinding = False
 bindingHasMetavars (LambdaBinding _) = False
 bindingHasMetavars (MetaBindings _) = True
 
@@ -170,6 +171,7 @@ hasAttr attr = any (isAttr attr)
   isAttr (ObjectAttr a) (AlphaBinding a' _) = a == a'
   isAttr (ObjectAttr a) (EmptyBinding a') = a == a'
   isAttr DeltaAttr (DeltaBinding _) = True
+  isAttr DeltaAttr DeltaEmptyBinding = True
   isAttr LambdaAttr (LambdaBinding _) = True
   isAttr _ _ = False
 
@@ -243,6 +245,7 @@ applySubstBinding subst@Subst{..} = \case
   EmptyBinding a ->
     [EmptyBinding (applySubstAttr subst a)]
   DeltaBinding bytes -> [DeltaBinding (coerce bytes)]
+  DeltaEmptyBinding -> [DeltaEmptyBinding]
   LambdaBinding bytes -> [LambdaBinding (coerce bytes)]
   b@(MetaBindings m) -> fromMaybe [b] (lookup m bindingsMetas)
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
@@ -33,6 +33,7 @@ data Binding
     = AlphaBinding Attribute Object
     | EmptyBinding Attribute
     | DeltaBinding Bytes
+    | DeltaEmptyBinding
     | LambdaBinding Function
     | MetaBindings MetaId
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
@@ -54,7 +54,7 @@ The symbols used in Syntax are the following:
   | ↦ | ∅ | ⤍ | ,
 
 ===Comments===
-There are no single-line comments in the grammar.There are no multiple-line comments in the grammar.
+Single-line comments begin with //.Multiple-line comments are  enclosed with /* and */.
 
 ==The syntactic structure of Syntax==
 Non-terminals are enclosed between < and >.

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
@@ -74,6 +74,7 @@ All other symbols are terminals.
   | //Binding// | -> | //Attribute// ``↦`` //Object//
   |  |  **|**  | //Attribute// ``↦`` ``∅``
   |  |  **|**  | ``Δ`` ``⤍`` //Bytes//
+  |  |  **|**  | ``Δ`` ``⤍`` ``∅``
   |  |  **|**  | ``λ`` ``⤍`` //Function//
   |  |  **|**  | //MetaId//
   | //[Binding]// | -> | **eps**

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Lex.x
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Lex.x
@@ -32,6 +32,12 @@ $u = [. \n]          -- universal: any character
 
 :-
 
+-- Line comment "//"
+"//" [.]* ;
+
+-- Block comment "/*" "*/"
+\/ \* [$u # \*]* \* ([$u # [\* \/]] [$u # \*]* \* | \*)* \/ ;
+
 -- Whitespace (skipped)
 $white+ ;
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
@@ -108,6 +108,7 @@ Binding
   : Attribute '↦' Object { Language.EO.Phi.Syntax.Abs.AlphaBinding $1 $3 }
   | Attribute '↦' '∅' { Language.EO.Phi.Syntax.Abs.EmptyBinding $1 }
   | 'Δ' '⤍' Bytes { Language.EO.Phi.Syntax.Abs.DeltaBinding $3 }
+  | 'Δ' '⤍' '∅' { Language.EO.Phi.Syntax.Abs.DeltaEmptyBinding }
   | 'λ' '⤍' Function { Language.EO.Phi.Syntax.Abs.LambdaBinding $3 }
   | MetaId { Language.EO.Phi.Syntax.Abs.MetaBindings $1 }
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
@@ -169,6 +169,7 @@ instance Print Language.EO.Phi.Syntax.Abs.Binding where
     Language.EO.Phi.Syntax.Abs.AlphaBinding attribute object -> prPrec i 0 (concatD [prt 0 attribute, doc (showString "\8614"), prt 0 object])
     Language.EO.Phi.Syntax.Abs.EmptyBinding attribute -> prPrec i 0 (concatD [prt 0 attribute, doc (showString "\8614"), doc (showString "\8709")])
     Language.EO.Phi.Syntax.Abs.DeltaBinding bytes -> prPrec i 0 (concatD [doc (showString "\916"), doc (showString "\10509"), prt 0 bytes])
+    Language.EO.Phi.Syntax.Abs.DeltaEmptyBinding -> prPrec i 0 (concatD [doc (showString "\916"), doc (showString "\10509"), doc (showString "\8709")])
     Language.EO.Phi.Syntax.Abs.LambdaBinding function -> prPrec i 0 (concatD [doc (showString "\955"), doc (showString "\10509"), prt 0 function])
     Language.EO.Phi.Syntax.Abs.MetaBindings metaid -> prPrec i 0 (concatD [prt 0 metaid])
 

--- a/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
@@ -70,6 +70,7 @@ instance Arbitrary Binding where
           return (AlphaBinding attr obj)
       , DeltaBinding <$> arbitrary
       , LambdaBinding <$> arbitrary
+      , pure DeltaEmptyBinding
       ]
   shrink (AlphaBinding VTX _) = [] -- do not shrink vertex bindings
   shrink (AlphaBinding attr obj) = AlphaBinding attr <$> shrink obj


### PR DESCRIPTION
I am divided between this approach and having a wrapper for `Bytes` that would be either `SomeBytes "..."` or `NoBytes`. What do you think?

Closes #181

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `DeltaEmptyBinding` type and updates related functions and parsers in the `eo-phi-normalizer` project.

### Detailed summary
- Added `DeltaEmptyBinding` type
- Updated functions and parsers to handle `DeltaEmptyBinding`
- Modified print and count functions for the new type

> The following files were skipped due to too many changes: `eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->