### PR TITLE
190 fix `scripts/try-unphi.sh`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ __pycache__
 pipeline/*
 !pipeline/config.yaml
 node_modules
+
+try-unphi

--- a/scripts/try-unphi.sh
+++ b/scripts/try-unphi.sh
@@ -53,6 +53,9 @@ EOM
         eo phi
     fi
 
+    rm -f .eoc/phi/test.phi
+    rm -f .eoc/2-optimize/test.xmir
+
     cd ..
 }
 
@@ -60,18 +63,18 @@ function unphi {
     printf "\nUnphi\n\n"
 
     cd tmp
+
     cp -r ../init/.eoc .
     cp -r ../phi/* .eoc/phi
 
-    rm .eoc/phi/test.phi
-
     eo unphi
+
     cp -r .eoc/unphi/!(org) .eoc/2-optimize
 
-    rm .eoc/2-optimize/test.xmir
-
     eo print
+
     cp -r .eoc/print/!(org) ../unphi
+
     cd ..
 }
 

--- a/scripts/try-unphi.sh
+++ b/scripts/try-unphi.sh
@@ -11,11 +11,15 @@ shopt -s extglob
 DIR=try-unphi
 
 function prepare_directory {
-    printf "\nClean the $DIR directory\n\n"
+    printf "\nPrepare the $DIR directory\n\n"
 
-    mkdir -p $DIR/init
     mkdir -p $DIR/phi
+    mkdir -p $DIR/init
+
+    rm -rf $DIR/tmp
     mkdir -p $DIR/tmp
+
+    rm -rf $DIR/unphi
     mkdir -p $DIR/unphi
 }
 
@@ -56,10 +60,16 @@ function unphi {
     printf "\nUnphi\n\n"
 
     cd tmp
-    cp -r ../phi/ .
     cp -r ../init/.eoc .
+    cp -r ../phi/* .eoc/phi
+
+    rm .eoc/phi/test.phi
+
     eo unphi
     cp -r .eoc/unphi/!(org) .eoc/2-optimize
+
+    rm .eoc/2-optimize/test.xmir
+
     eo print
     cp -r .eoc/print/!(org) ../unphi
     cd ..

--- a/scripts/try-unphi.sh
+++ b/scripts/try-unphi.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 if ! [ -d node_modules ]; then npm i; fi
 
 shopt -s expand_aliases
-EO="0.35.5"
+EO="0.35.8"
 alias eo="npx eoc --parser=${EO}"
 
 DIR=try-unphi

--- a/scripts/try-unphi.sh
+++ b/scripts/try-unphi.sh
@@ -6,6 +6,8 @@ shopt -s expand_aliases
 EO="0.35.8"
 alias eo="npx eoc --parser=${EO}"
 
+shopt -s extglob
+
 DIR=try-unphi
 
 function prepare_directory {
@@ -54,12 +56,12 @@ function unphi {
     printf "\nUnphi\n\n"
 
     cd tmp
-    rsync -r ../phi/ .
-    rsync -r ../init/.eoc .
+    cp -r ../phi/ .
+    cp -r ../init/.eoc .
     eo unphi
-    rsync -r .eoc/unphi/ --exclude org .eoc/2-optimize
+    cp -r .eoc/unphi/!(org) .eoc/2-optimize
     eo print
-    rsync -r .eoc/print/ --exclude org ../unphi
+    cp -r .eoc/print/!(org) ../unphi
     cd ..
 }
 


### PR DESCRIPTION
Closes #190

## Context

`scripts/try-unphi.sh` is to experiment with PHI -> EO translations.

Run `./scripts/try-unphi.sh`. After that, put some PHI files in `try-unphi/phi`


<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the script `prepare_directory` to include new directory operations and improves file handling in the `unphi` function.

### Detailed summary
- Updated directory operations in `prepare_directory`
- Improved file handling in `unphi` function
- Updated `EO` version from 0.35.5 to 0.35.8
- Added `try-unphi` directory to `.gitignore`
- Added `try-unphi` and `scripts/try-unphi.sh` to the project

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->