### PR TITLE
Refactor CLI and metrics

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -65,7 +65,7 @@
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
 - ignore:
     name: Unused LANGUAGE pragma
-    within: Language.EO.Phi.Metrics.Collect
+    within: Language.EO.Phi.Metrics
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -212,6 +212,9 @@ getLoggers outputFile = do
     , \x -> hPutStr handle x >> hFlush handle
     )
 
+getParserContext :: String -> ParserInfo a -> Optparse.Context
+getParserContext = Optparse.Context
+
 -- >>> splitStringOn '.' "abra.cada.bra"
 -- ["abra","cada","bra"]
 --
@@ -228,7 +231,7 @@ main = do
         x -> printTree x
   case opts of
     CLI'MetricsPhi' CLI'MetricsPhi{..} -> do
-      let parserContext = Optparse.Context commandNames.metrics commandParserInfo.metrics
+      let parserContext = getParserContext commandNames.metrics commandParserInfo.metrics
       program <- getProgram parserContext inputFile
       (logStrLn, _) <- getLoggers outputFile
       let path = splitStringOn '.' (fromMaybe "" programPath)
@@ -244,7 +247,7 @@ main = do
         Right metrics' -> do
           logStrLn $ encodeToJSONString metrics'
     CLI'TransformPhi' CLI'TransformPhi{..} -> do
-      let parserContext = Optparse.Context commandNames.transform commandParserInfo.transform
+      let parserContext = getParserContext commandNames.transform commandParserInfo.transform
       program' <- getProgram parserContext inputFile
       (logStrLn, logStr) <- getLoggers outputFile
       ruleSet <- parseRuleSetFromFile rulesPath

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -27,7 +27,7 @@ import Data.Text.Internal.Builder (toLazyText)
 import Data.Text.Lazy.Lens
 import GHC.Generics (Generic)
 import Language.EO.Phi (Attribute (Sigma), Object (Formation), Program (Program), parseProgram, printTree)
-import Language.EO.Phi.Metrics.Collect (collectMetrics)
+import Language.EO.Phi.Metrics (collectMetrics)
 import Language.EO.Phi.Rules.Common (ApplicationLimits (ApplicationLimits), Context (..), applyRulesChainWith, applyRulesWith, objectSize)
 import Language.EO.Phi.Rules.Yaml (RuleSet (rules, title), convertRule, parseRuleSetFromFile)
 import Options.Applicative

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -22,10 +22,9 @@ import Data.Foldable (forM_)
 import Control.Lens ((^.))
 import Data.Aeson (ToJSON)
 import Data.Aeson.Encode.Pretty (Config (..), Indent (..), defConfig, encodePrettyToTextBuilder')
-import Data.List (intercalate)
+import Data.List (groupBy, intercalate)
 import Data.Maybe (fromMaybe)
 import Data.String.Interpolate (i, iii)
-import Data.Text qualified as T
 import Data.Text.Internal.Builder (toLazyText)
 import Data.Text.Lazy.Lens
 import GHC.Generics (Generic)
@@ -192,13 +191,13 @@ getLoggers outputFile = do
     , \x -> hPutStr handle x >> hFlush handle
     )
 
--- >>> splitStringOn "." "abra.cada.bra"
+-- >>> splitStringOn '.' "abra.cada.bra"
 -- ["abra","cada","bra"]
 --
--- >>> splitStringOn "." ""
+-- >>> splitStringOn '.' ""
 -- []
-splitStringOn :: String -> String -> [String]
-splitStringOn sep s = filter (not . null) $ T.unpack <$> T.splitOn (T.pack sep) (T.pack s)
+splitStringOn :: Char -> String -> [String]
+splitStringOn sep = filter (/= [sep]) . groupBy (\a b -> a /= sep && b /= sep)
 
 main :: IO ()
 main = do
@@ -211,7 +210,7 @@ main = do
       let parserContext = Optparse.Context metricsCommandName metricsParserInfo
       program <- getProgram parserContext inputFile
       (logStrLn, _) <- getLoggers outputFile
-      let path = splitStringOn "." (fromMaybe "" programPath)
+      let path = splitStringOn '.' (fromMaybe "" programPath)
           metrics = getProgramMetrics path program
       case metrics of
         Left path' ->

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -333,9 +333,6 @@ main = do
             ctx = defaultContext (convertRule <$> ruleSet.rules) (Formation bindings)
           totalResults = length uniqueResults
       when (null uniqueResults || null (head uniqueResults)) (throw CouldNotNormalize)
-      let printAsProgramOrAsObject = \case
-            Formation bindings' -> printTree $ Program bindings'
-            x -> printTree x
       if
         | single && json ->
             logStrLn

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -45,6 +45,7 @@ library
       Language.EO.Phi.Syntax.Lex
       Language.EO.Phi.Syntax.Par
       Language.EO.Phi.Syntax.Print
+      Language.EO.Phi.TH
   other-modules:
       Paths_eo_phi_normalizer
   hs-source-dirs:
@@ -67,6 +68,7 @@ library
     , lens
     , mtl
     , string-interpolate
+    , template-haskell
     , text
     , yaml
   default-language: Haskell2010
@@ -98,6 +100,7 @@ executable normalizer
     , mtl
     , optparse-applicative
     , string-interpolate
+    , template-haskell
     , text
     , yaml
   default-language: Haskell2010
@@ -137,6 +140,7 @@ test-suite spec
     , lens
     , mtl
     , string-interpolate
+    , template-haskell
     , text
     , yaml
   default-language: Haskell2010

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -34,7 +34,7 @@ custom-setup
 library
   exposed-modules:
       Language.EO.Phi
-      Language.EO.Phi.Metrics.Collect
+      Language.EO.Phi.Metrics
       Language.EO.Phi.Normalize
       Language.EO.Phi.Rules.Common
       Language.EO.Phi.Rules.PhiPaper

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -47,6 +47,7 @@ dependencies:
   - lens
   - generic-lens
   - text
+  - template-haskell
 
 default-extensions:
   - ImportQualifiedPost

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -19,13 +20,13 @@ module Language.EO.Phi.Metrics where
 import Control.Lens ((+=))
 import Control.Monad (forM_)
 import Control.Monad.State (State, execState, runState)
-import Data.Aeson (FromJSON)
-import Data.Aeson.Types (ToJSON)
 import Data.Generics.Labels ()
+import Data.List (intercalate)
 import Data.Traversable (forM)
 import GHC.Generics (Generic)
 import Language.EO.Phi.Rules.Common ()
 import Language.EO.Phi.Syntax.Abs
+import Language.EO.Phi.TH
 
 data Metrics = Metrics
   { dataless :: Int
@@ -33,7 +34,9 @@ data Metrics = Metrics
   , formations :: Int
   , dispatches :: Int
   }
-  deriving (Generic, Show, FromJSON, ToJSON, Eq)
+  deriving (Generic, Show, Eq)
+
+$(deriveJSON ''Metrics)
 
 defaultMetrics :: Metrics
 defaultMetrics =
@@ -62,7 +65,9 @@ data BindingMetrics = BindingMetrics
   { name :: String
   , metrics :: Metrics
   }
-  deriving (Show, Generic, FromJSON, ToJSON, Eq)
+  deriving (Show, Generic, Eq)
+
+$(deriveJSON ''BindingMetrics)
 
 count :: (a -> Bool) -> [a] -> Int
 count x = length . filter x
@@ -119,13 +124,17 @@ data BindingsByPathMetrics = BindingsByPathMetrics
   { path :: Path
   , bindingsMetrics :: [BindingMetrics]
   }
-  deriving (Show, Generic, FromJSON, ToJSON, Eq)
+  deriving (Show, Generic, Eq)
+
+$(deriveJSON ''BindingsByPathMetrics)
 
 data ObjectMetrics = ObjectMetrics
   { bindingsByPathMetrics :: Maybe BindingsByPathMetrics
   , thisObjectMetrics :: Metrics
   }
-  deriving (Show, Generic, FromJSON, ToJSON, Eq)
+  deriving (Show, Generic, Eq)
+
+$(deriveJSON ''ObjectMetrics)
 
 -- | Get metrics for an object
 --
@@ -235,7 +244,9 @@ data ProgramMetrics = ProgramMetrics
   { bindingsByPathMetrics :: Maybe BindingsByPathMetrics
   , programMetrics :: Metrics
   }
-  deriving (Show, Generic, FromJSON, ToJSON, Eq)
+  deriving (Show, Generic, Eq)
+
+$(deriveJSON ''ProgramMetrics)
 
 -- | Get metrics for a program and for bindings of a formation accessible by a given path.
 --

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -17,7 +15,7 @@
 
 {- FOURMOLU_ENABLE -}
 
-module Language.EO.Phi.Metrics.Collect where
+module Language.EO.Phi.Metrics where
 
 import Control.Lens ((+=))
 import Control.Monad (forM_)

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
@@ -241,12 +241,13 @@ data ProgramMetrics = ProgramMetrics
 --
 -- Combine metrics produced by 'getThisObjectMetrics' and 'getBindingsByPathMetrics'.
 --
--- If no formation is accessible by the path, return a prefix of the path that led to a non-formation when the remaining path wasn't empty.
 -- >>> getProgramMetrics ["org", "eolang"] "{⟦ org ↦ ⟦ eolang ↦ ⟦ x ↦ ⟦ φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, z ↦ ⟦ y ↦ ⟦ x ↦ ∅, φ ↦ ξ.x ⟧, φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧⟧ }"
--- Right (Formation [AlphaBinding (Label (LabelId "x")) (Formation [AlphaBinding Phi (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bool"))) [AlphaBinding (Alpha (AlphaIndex "\945\&0")) (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bytes"))) [DeltaBinding (Bytes "01-")])])]),AlphaBinding (Label (LabelId "z")) (Formation [AlphaBinding (Label (LabelId "y")) (Formation [EmptyBinding (Label (LabelId "x")),AlphaBinding Phi (ObjectDispatch ThisObject (Label (LabelId "x")))]),AlphaBinding Phi (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bool"))) [AlphaBinding (Alpha (AlphaIndex "\945\&0")) (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bytes"))) [DeltaBinding (Bytes "01-")])])]),LambdaBinding (Function "Package")])
+-- Right (ProgramMetrics {bindingsByPathMetrics = BindingsByPathMetrics {path = ["org","eolang"], bindingsMetrics = [BindingMetrics {name = "x", metrics = Metrics {dataless = 0, applications = 2, formations = 1, dispatches = 6}},BindingMetrics {name = "z", metrics = Metrics {dataless = 0, applications = 2, formations = 2, dispatches = 7}}]}, programMetrics = Metrics {dataless = 0, applications = 4, formations = 6, dispatches = 13}})
+--
+-- If no formation is accessible by the path, return a prefix of the path that led to a non-formation when the remaining path wasn't empty.
 --
 -- >>> getProgramMetrics ["a"] "{⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧}"
--- Right (ObjectDispatch (Formation [AlphaBinding (Label (LabelId "b")) (Formation [EmptyBinding (Label (LabelId "c")),AlphaBinding (Label (LabelId "d")) (Formation [AlphaBinding Phi (ObjectDispatch (ObjectDispatch ThisObject Rho) (Label (LabelId "c")))])]),AlphaBinding (Label (LabelId "e")) (ObjectDispatch (Application (ObjectDispatch ThisObject (Label (LabelId "b"))) [AlphaBinding (Label (LabelId "c")) (Formation [])]) (Label (LabelId "d")))]) (Label (LabelId "e")))
+-- Left ["a"]
 getProgramMetrics :: Path -> Program -> Either Path ProgramMetrics
 getProgramMetrics path (Program bindings) = do
   ObjectMetrics{..} <- getObjectMetrics path (Formation bindings)

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
@@ -21,7 +21,7 @@ import Control.Lens ((+=))
 import Control.Monad (forM_)
 import Control.Monad.State (State, execState, runState)
 import Data.Generics.Labels ()
-import Data.List (intercalate)
+import Data.List (groupBy, intercalate)
 import Data.Traversable (forM)
 import GHC.Generics (Generic)
 import Language.EO.Phi.Rules.Common ()
@@ -135,6 +135,17 @@ data ObjectMetrics = ObjectMetrics
   deriving (Show, Generic, Eq)
 
 $(deriveJSON ''ObjectMetrics)
+
+-- >>> splitStringOn '.' "abra.cada.bra"
+-- ["abra","cada","bra"]
+--
+-- >>> splitStringOn '.' ""
+-- []
+splitStringOn :: Char -> String -> [String]
+splitStringOn sep = filter (/= [sep]) . groupBy (\a b -> a /= sep && b /= sep)
+
+splitPath :: String -> [String]
+splitPath = splitStringOn '.'
 
 -- | Get metrics for an object
 --

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
@@ -25,7 +25,6 @@ import Data.Aeson.Types (ToJSON)
 import Data.Foldable (fold)
 import Data.Function ((&))
 import Data.Generics.Labels ()
-import Data.Maybe (catMaybes)
 import Data.Traversable (forM)
 import GHC.Generics (Generic)
 import Language.EO.Phi.Rules.Common ()
@@ -71,13 +70,16 @@ data BindingMetrics = BindingMetrics
 count :: (a -> Bool) -> [a] -> Int
 count x = length . filter x
 
-getHeight :: (Ord b, Num b) => [Binding] -> [Maybe b] -> b
+getHeight :: [Binding] -> [Int] -> Int
 getHeight bindings heights
-  | hasDeltaAttribute = 1
+  | hasDeltaBinding = 1
   | otherwise = heightAttributes
  where
-  heightAttributes = heights & catMaybes & (\case [] -> 0; x -> minimum x + 1)
-  hasDeltaAttribute = not $ null [x | x@(DeltaBinding _, _) <- zip bindings heights]
+  heightAttributes =
+    case heights of
+      [] -> 0
+      _ -> minimum heights + 1
+  hasDeltaBinding = not $ null [undefined | DeltaBinding _ <- bindings]
 
 countDataless :: Int -> Int
 countDataless x
@@ -85,34 +87,34 @@ countDataless x
   | otherwise = 0
 
 class Inspectable a where
-  inspect :: a -> State ObjectMetrics (Maybe Int)
+  inspect :: a -> State ObjectMetrics Int
 
 instance Inspectable Binding where
-  inspect :: Binding -> State ObjectMetrics (Maybe Int)
+  inspect :: Binding -> State ObjectMetrics Int
   inspect = \case
     AlphaBinding _ obj -> do
       inspect obj
-    _ -> pure Nothing
+    _ -> pure 0
 
 instance Inspectable Object where
-  inspect :: Object -> State ObjectMetrics (Maybe Int)
+  inspect :: Object -> State ObjectMetrics Int
   inspect = \case
     Formation bindings -> do
       #formations += 1
       heights <- forM bindings inspect
       let height = getHeight bindings heights
       #dataless += countDataless height
-      pure (Just height)
+      pure height
     Application obj bindings -> do
       #applications += 1
       _ <- inspect obj
       forM_ bindings inspect
-      pure Nothing
+      pure 0
     ObjectDispatch obj _ -> do
       #dispatches += 1
       _ <- inspect obj
-      pure Nothing
-    _ -> pure Nothing
+      pure 0
+    _ -> pure 0
 
 data ProgramMetrics = ProgramMetrics
   { attributes :: [BindingMetrics]
@@ -130,7 +132,7 @@ defaultMetrics =
 -- | Count dataless formations in a list of bindings
 --
 -- >>> collectMetrics "{⟦ α0 ↦ ξ, α0 ↦ Φ.org.eolang.bytes( Δ ⤍ 00- ) ⟧}"
--- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}},BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 1, formations = 0, dispatches = 3}}], program = ObjectMetrics {dataless = 1, applications = 1, formations = 1, dispatches = 3}}
+-- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}},BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 1, formations = 0, dispatches = 3}}], program = ObjectMetrics {dataless = 0, applications = 1, formations = 1, dispatches = 3}}
 --
 -- >>> collectMetrics "{⟦ α0 ↦ ξ, Δ ⤍ 00- ⟧}"
 -- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}}], program = ObjectMetrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}}
@@ -141,16 +143,16 @@ defaultMetrics =
 --
 --
 -- >>> collectMetrics "{⟦ α0 ↦ ξ, α1 ↦ ⟦ α2 ↦ ⟦ Δ ⤍ 00- ⟧ ⟧ ⟧}"
--- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}},BindingMetrics {name = "\945\&1", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}], program = ObjectMetrics {dataless = 1, applications = 0, formations = 3, dispatches = 0}}
+-- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}},BindingMetrics {name = "\945\&1", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}], program = ObjectMetrics {dataless = 0, applications = 0, formations = 3, dispatches = 0}}
 --
 -- >>> collectMetrics "{⟦ Δ ⤍ 00- ⟧}"
 -- ProgramMetrics {attributes = [], program = ObjectMetrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}}
 --
 -- >>> collectMetrics "{⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧}"
--- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 1, applications = 0, formations = 1, dispatches = 0}}], program = ObjectMetrics {dataless = 1, applications = 0, formations = 2, dispatches = 0}}
+-- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}}], program = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}
 --
 -- >>> collectMetrics "{⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧ ⟧}"
--- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 1, applications = 0, formations = 2, dispatches = 0}}], program = ObjectMetrics {dataless = 1, applications = 0, formations = 3, dispatches = 0}}
+-- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}], program = ObjectMetrics {dataless = 1, applications = 0, formations = 3, dispatches = 0}}
 --
 -- >>> collectMetrics "{⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧ ⟧ ⟧}"
 -- ProgramMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 1, applications = 0, formations = 3, dispatches = 0}}], program = ObjectMetrics {dataless = 2, applications = 0, formations = 4, dispatches = 0}}

--- a/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs
@@ -1,13 +1,18 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Language.EO.Phi.Metrics where
 
@@ -16,15 +21,13 @@ import Control.Monad (forM_)
 import Control.Monad.State (State, execState, runState)
 import Data.Aeson (FromJSON)
 import Data.Aeson.Types (ToJSON)
-import Data.Foldable (fold)
-import Data.Function ((&))
 import Data.Generics.Labels ()
 import Data.Traversable (forM)
 import GHC.Generics (Generic)
 import Language.EO.Phi.Rules.Common ()
 import Language.EO.Phi.Syntax.Abs
 
-data ObjectMetrics = ObjectMetrics
+data Metrics = Metrics
   { dataless :: Int
   , applications :: Int
   , formations :: Int
@@ -32,32 +35,32 @@ data ObjectMetrics = ObjectMetrics
   }
   deriving (Generic, Show, FromJSON, ToJSON, Eq)
 
-defaultObjectMetrics :: ObjectMetrics
-defaultObjectMetrics =
-  ObjectMetrics
+defaultMetrics :: Metrics
+defaultMetrics =
+  Metrics
     { dataless = 0
     , applications = 0
     , formations = 0
     , dispatches = 0
     }
 
-instance Semigroup ObjectMetrics where
-  (<>) :: ObjectMetrics -> ObjectMetrics -> ObjectMetrics
+instance Semigroup Metrics where
+  (<>) :: Metrics -> Metrics -> Metrics
   x <> y =
-    ObjectMetrics
+    Metrics
       { dataless = x.dataless + y.dataless
       , applications = x.applications + y.applications
       , formations = x.formations + y.formations
       , dispatches = x.dispatches + y.dispatches
       }
 
-instance Monoid ObjectMetrics where
-  mempty :: ObjectMetrics
-  mempty = defaultObjectMetrics
+instance Monoid Metrics where
+  mempty :: Metrics
+  mempty = defaultMetrics
 
 data BindingMetrics = BindingMetrics
   { name :: String
-  , metrics :: ObjectMetrics
+  , metrics :: Metrics
   }
   deriving (Show, Generic, FromJSON, ToJSON, Eq)
 
@@ -81,17 +84,17 @@ countDataless x
   | otherwise = 0
 
 class Inspectable a where
-  inspect :: a -> State ObjectMetrics Int
+  inspect :: a -> State Metrics Int
 
 instance Inspectable Binding where
-  inspect :: Binding -> State ObjectMetrics Int
+  inspect :: Binding -> State Metrics Int
   inspect = \case
     AlphaBinding _ obj -> do
       inspect obj
     _ -> pure 0
 
 instance Inspectable Object where
-  inspect :: Object -> State ObjectMetrics Int
+  inspect :: Object -> State Metrics Int
   inspect = \case
     Formation bindings -> do
       #formations += 1
@@ -110,80 +113,64 @@ instance Inspectable Object where
       pure 0
     _ -> pure 0
 
-data CompleteMetrics = CompleteMetrics
-  { attributes :: [BindingMetrics]
-  , this :: ObjectMetrics
+type Path = [String]
+
+data BindingsByPathMetrics = BindingsByPathMetrics
+  { path :: Path
+  , bindingsMetrics :: [BindingMetrics]
   }
   deriving (Show, Generic, FromJSON, ToJSON, Eq)
 
-defaultMetrics :: CompleteMetrics
-defaultMetrics =
-  CompleteMetrics
-    { attributes = []
-    , this = defaultObjectMetrics
-    }
+data ObjectMetrics = ObjectMetrics
+  { bindingsByPathMetrics :: BindingsByPathMetrics
+  , thisObjectMetrics :: Metrics
+  }
+  deriving (Show, Generic, FromJSON, ToJSON, Eq)
 
--- | Collect metrics for an object
+-- | Get metrics for an object
 --
--- When an object is a formation, provide metrics for its attributes and metrics for the object.
+-- >>> getThisObjectMetrics "⟦ α0 ↦ ξ, α0 ↦ Φ.org.eolang.bytes( Δ ⤍ 00- ) ⟧"
+-- Metrics {dataless = 0, applications = 1, formations = 1, dispatches = 3}
 --
--- >>> collectCompleteMetrics "⟦ α0 ↦ ξ, α0 ↦ Φ.org.eolang.bytes( Δ ⤍ 00- ) ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}},BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 1, formations = 0, dispatches = 3}}], this = ObjectMetrics {dataless = 0, applications = 1, formations = 1, dispatches = 3}}
+-- >>> getThisObjectMetrics "⟦ α0 ↦ ξ, Δ ⤍ 00- ⟧"
+-- Metrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ α0 ↦ ξ, Δ ⤍ 00- ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}}], this = ObjectMetrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}}
+-- >>> getThisObjectMetrics "⟦ α0 ↦ ξ, α1 ↦ ⟦ Δ ⤍ 00- ⟧ ⟧"
+-- Metrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ α0 ↦ ξ, α1 ↦ ⟦ Δ ⤍ 00- ⟧ ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}},BindingMetrics {name = "\945\&1", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}}], this = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}
+-- >>> getThisObjectMetrics "⟦ α0 ↦ ξ, α1 ↦ ⟦ α2 ↦ ⟦ Δ ⤍ 00- ⟧ ⟧ ⟧"
+-- Metrics {dataless = 0, applications = 0, formations = 3, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ α0 ↦ ξ, α1 ↦ ⟦ α2 ↦ ⟦ Δ ⤍ 00- ⟧ ⟧ ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 0, dispatches = 0}},BindingMetrics {name = "\945\&1", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}], this = ObjectMetrics {dataless = 0, applications = 0, formations = 3, dispatches = 0}}
+-- >>> getThisObjectMetrics "⟦ Δ ⤍ 00- ⟧"
+-- Metrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ Δ ⤍ 00- ⟧"
--- CompleteMetrics {attributes = [], this = ObjectMetrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}}
+-- >>> getThisObjectMetrics "⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧"
+-- Metrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 1, dispatches = 0}}], this = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}
+-- >>> getThisObjectMetrics "⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧ ⟧"
+-- Metrics {dataless = 1, applications = 0, formations = 3, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧ ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 0, applications = 0, formations = 2, dispatches = 0}}], this = ObjectMetrics {dataless = 1, applications = 0, formations = 3, dispatches = 0}}
+-- >>> getThisObjectMetrics "⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧ ⟧ ⟧"
+-- Metrics {dataless = 2, applications = 0, formations = 4, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ⟦ α0 ↦ ∅ ⟧ ⟧ ⟧ ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "\945\&0", metrics = ObjectMetrics {dataless = 1, applications = 0, formations = 3, dispatches = 0}}], this = ObjectMetrics {dataless = 2, applications = 0, formations = 4, dispatches = 0}}
+-- >>> getThisObjectMetrics "⟦ org ↦ ⟦ ⟧ ⟧"
+-- Metrics {dataless = 1, applications = 0, formations = 2, dispatches = 0}
 --
--- >>> collectCompleteMetrics "⟦ org ↦ ⟦ ⟧ ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "org", metrics = ObjectMetrics {dataless = 1, applications = 0, formations = 1, dispatches = 0}}], this = ObjectMetrics {dataless = 1, applications = 0, formations = 2, dispatches = 0}}
---
--- >>> collectCompleteMetrics "⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧"
--- CompleteMetrics {attributes = [BindingMetrics {name = "a", metrics = ObjectMetrics {dataless = 1, applications = 1, formations = 4, dispatches = 5}}], this = ObjectMetrics {dataless = 1, applications = 1, formations = 5, dispatches = 5}}
-collectCompleteMetrics :: Object -> CompleteMetrics
-collectCompleteMetrics = \case
-  Formation bindings ->
-    let attributes' = flip runState mempty . inspect <$> bindings
-        (heights, objectMetrics) = unzip attributes'
-        attributes = do
-          x <- zip bindings objectMetrics
-          case x of
-            (AlphaBinding (Alpha (AlphaIndex name)) _, metrics) -> [BindingMetrics{..}]
-            (AlphaBinding (Label (LabelId name)) _, metrics) -> [BindingMetrics{..}]
-            _ -> []
-        height = getHeight bindings heights
-        this =
-          fold objectMetrics
-            & \x ->
-              x
-                { dataless = x.dataless + countDataless height
-                , formations = x.formations + 1
-                }
-     in CompleteMetrics{..}
-  obj ->
-    CompleteMetrics
-      { attributes = []
-      , this = execState (inspect obj) mempty
-      }
+-- >>> getThisObjectMetrics "⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧"
+-- Metrics {dataless = 1, applications = 1, formations = 5, dispatches = 5}
+getThisObjectMetrics :: Object -> Metrics
+getThisObjectMetrics obj = execState (inspect obj) mempty
 
-objectByPath :: [String] -> Object -> Either [String] Object
-objectByPath path object =
+-- | Get an object by a path within a given object.
+--
+-- If no object is accessible by the path, return a prefix of the path that led to a non-formation when the remaining path wasn't empty.
+-- >>> getObjectByPath ["org", "eolang"] "⟦ org ↦ ⟦ eolang ↦ ⟦ x ↦ ⟦ φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, z ↦ ⟦ y ↦ ⟦ x ↦ ∅, φ ↦ ξ.x ⟧, φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧⟧"
+-- Right (Formation [AlphaBinding (Label (LabelId "x")) (Formation [AlphaBinding Phi (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bool"))) [AlphaBinding (Alpha (AlphaIndex "\945\&0")) (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bytes"))) [DeltaBinding (Bytes "01-")])])]),AlphaBinding (Label (LabelId "z")) (Formation [AlphaBinding (Label (LabelId "y")) (Formation [EmptyBinding (Label (LabelId "x")),AlphaBinding Phi (ObjectDispatch ThisObject (Label (LabelId "x")))]),AlphaBinding Phi (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bool"))) [AlphaBinding (Alpha (AlphaIndex "\945\&0")) (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bytes"))) [DeltaBinding (Bytes "01-")])])]),LambdaBinding (Function "Package")])
+--
+-- >>> getObjectByPath ["a"] "⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧"
+-- Right (ObjectDispatch (Formation [AlphaBinding (Label (LabelId "b")) (Formation [EmptyBinding (Label (LabelId "c")),AlphaBinding (Label (LabelId "d")) (Formation [AlphaBinding Phi (ObjectDispatch (ObjectDispatch ThisObject Rho) (Label (LabelId "c")))])]),AlphaBinding (Label (LabelId "e")) (ObjectDispatch (Application (ObjectDispatch ThisObject (Label (LabelId "b"))) [AlphaBinding (Label (LabelId "c")) (Formation [])]) (Label (LabelId "d")))]) (Label (LabelId "e")))
+getObjectByPath :: Path -> Object -> Either Path Object
+getObjectByPath path object =
   case path of
     [] -> Right object
     (p : ps) ->
@@ -198,16 +185,69 @@ objectByPath path object =
               x <- bindings
               Right obj <-
                 case x of
-                  AlphaBinding (Alpha (AlphaIndex name)) obj | name == p -> [objectByPath ps obj]
-                  AlphaBinding (Label (LabelId name)) obj | name == p -> [objectByPath ps obj]
+                  AlphaBinding (Alpha (AlphaIndex name)) obj | name == p -> [getObjectByPath ps obj]
+                  AlphaBinding (Label (LabelId name)) obj | name == p -> [getObjectByPath ps obj]
                   _ -> [Left path]
               pure obj
         _ -> Left path
 
--- >>> programObjectByPath ["org", "eolang"] "{⟦ org ↦ ⟦ eolang ↦ ⟦ x ↦ ⟦ φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, z ↦ ⟦ y ↦ ⟦ x ↦ ∅, φ ↦ ξ.x ⟧, φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧⟧ }"
+-- | Get metrics for bindings of a formation that is accessible by a path within a given object.
+--
+-- If no formation is accessible by the path, return a prefix of the path that led to a non-formation when the remaining path wasn't empty.
+-- >>> getBindingsByPathMetrics ["a"] "⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧"
+-- Left ["a"]
+--
+-- >>> getBindingsByPathMetrics ["a"] "⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧ ⟧"
+-- Right (BindingsByPathMetrics {path = ["a"], bindingsMetrics = [BindingMetrics {name = "b", metrics = Metrics {dataless = 0, applications = 0, formations = 2, dispatches = 2}},BindingMetrics {name = "e", metrics = Metrics {dataless = 1, applications = 1, formations = 1, dispatches = 2}}]})
+getBindingsByPathMetrics :: Path -> Object -> Either Path BindingsByPathMetrics
+getBindingsByPathMetrics path obj =
+  case getObjectByPath path obj of
+    Right (Formation bindings) ->
+      let attributes' = flip runState mempty . inspect <$> bindings
+          (_, objectMetrics) = unzip attributes'
+          bindingsMetrics = do
+            x <- zip bindings objectMetrics
+            case x of
+              (AlphaBinding (Alpha (AlphaIndex name)) _, metrics) -> [BindingMetrics{..}]
+              (AlphaBinding (Label (LabelId name)) _, metrics) -> [BindingMetrics{..}]
+              _ -> []
+       in Right $ BindingsByPathMetrics{..}
+    Right _ -> Left path
+    Left path' -> Left path'
+
+-- | Get metrics for an object and for bindings of a formation accessible by a given path.
+--
+-- Combine metrics produced by 'getThisObjectMetrics' and 'getBindingsByPathMetrics'.
+--
+-- If no formation is accessible by the path, return a prefix of the path that led to a non-formation when the remaining path wasn't empty.
+-- >>> getObjectMetrics ["a"] "⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧"
+-- Left ["a"]
+--
+-- >>> getObjectMetrics ["a"] "⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧ ⟧"
+-- Right (ObjectMetrics {bindingsByPathMetrics = BindingsByPathMetrics {path = ["a"], bindingsMetrics = [BindingMetrics {name = "b", metrics = Metrics {dataless = 0, applications = 0, formations = 2, dispatches = 2}},BindingMetrics {name = "e", metrics = Metrics {dataless = 1, applications = 1, formations = 1, dispatches = 2}}]}, thisObjectMetrics = Metrics {dataless = 1, applications = 1, formations = 5, dispatches = 4}})
+getObjectMetrics :: Path -> Object -> Either Path ObjectMetrics
+getObjectMetrics path obj = do
+  let thisObjectMetrics = getThisObjectMetrics obj
+  bindingsByPathMetrics <- getBindingsByPathMetrics path obj
+  pure ObjectMetrics{..}
+
+data ProgramMetrics = ProgramMetrics
+  { bindingsByPathMetrics :: BindingsByPathMetrics
+  , programMetrics :: Metrics
+  }
+  deriving (Show, Generic, FromJSON, ToJSON, Eq)
+
+-- | Get metrics for a program and for bindings of a formation accessible by a given path.
+--
+-- Combine metrics produced by 'getThisObjectMetrics' and 'getBindingsByPathMetrics'.
+--
+-- If no formation is accessible by the path, return a prefix of the path that led to a non-formation when the remaining path wasn't empty.
+-- >>> getProgramMetrics ["org", "eolang"] "{⟦ org ↦ ⟦ eolang ↦ ⟦ x ↦ ⟦ φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, z ↦ ⟦ y ↦ ⟦ x ↦ ∅, φ ↦ ξ.x ⟧, φ ↦ Φ.org.eolang.bool ( α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 01-) ) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧⟧ }"
 -- Right (Formation [AlphaBinding (Label (LabelId "x")) (Formation [AlphaBinding Phi (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bool"))) [AlphaBinding (Alpha (AlphaIndex "\945\&0")) (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bytes"))) [DeltaBinding (Bytes "01-")])])]),AlphaBinding (Label (LabelId "z")) (Formation [AlphaBinding (Label (LabelId "y")) (Formation [EmptyBinding (Label (LabelId "x")),AlphaBinding Phi (ObjectDispatch ThisObject (Label (LabelId "x")))]),AlphaBinding Phi (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bool"))) [AlphaBinding (Alpha (AlphaIndex "\945\&0")) (Application (ObjectDispatch (ObjectDispatch (ObjectDispatch GlobalObject (Label (LabelId "org"))) (Label (LabelId "eolang"))) (Label (LabelId "bytes"))) [DeltaBinding (Bytes "01-")])])]),LambdaBinding (Function "Package")])
 --
--- >>> programObjectByPath ["a"] "{⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧}"
+-- >>> getProgramMetrics ["a"] "{⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b(c ↦ ⟦⟧).d ⟧.e ⟧}"
 -- Right (ObjectDispatch (Formation [AlphaBinding (Label (LabelId "b")) (Formation [EmptyBinding (Label (LabelId "c")),AlphaBinding (Label (LabelId "d")) (Formation [AlphaBinding Phi (ObjectDispatch (ObjectDispatch ThisObject Rho) (Label (LabelId "c")))])]),AlphaBinding (Label (LabelId "e")) (ObjectDispatch (Application (ObjectDispatch ThisObject (Label (LabelId "b"))) [AlphaBinding (Label (LabelId "c")) (Formation [])]) (Label (LabelId "d")))]) (Label (LabelId "e")))
-programObjectByPath :: [String] -> Program -> Either [String] Object
-programObjectByPath path (Program bindings) = objectByPath path (Formation bindings)
+getProgramMetrics :: Path -> Program -> Either Path ProgramMetrics
+getProgramMetrics path (Program bindings) = do
+  ObjectMetrics{..} <- getObjectMetrics path (Formation bindings)
+  pure ProgramMetrics{programMetrics = thisObjectMetrics, ..}

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -301,9 +301,9 @@ newtype MetaState = MetaState
 
 evaluateMetaFuncs' :: Object -> State MetaState Object
 evaluateMetaFuncs' (MetaFunction (MetaFunctionName "@T") _) = do
-  res <- gets (Common.intToBytesObject . nuCount)
+  nuCount' <- gets (Common.intToBytesObject . nuCount)
   #nuCount += 1
-  pure res
+  pure nuCount'
 evaluateMetaFuncs' (Formation bindings) = Formation <$> mapM evaluateMetaFuncsBinding bindings
 evaluateMetaFuncs' (Application obj bindings) = Application <$> evaluateMetaFuncs' obj <*> mapM evaluateMetaFuncsBinding bindings
 evaluateMetaFuncs' (ObjectDispatch obj a) = ObjectDispatch <$> evaluateMetaFuncs' obj <*> pure a

--- a/eo-phi-normalizer/src/Language/EO/Phi/TH.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/TH.hs
@@ -1,0 +1,12 @@
+module Language.EO.Phi.TH where
+
+import Data.Aeson (Options (..), camelTo2)
+import Data.Aeson.TH as TH (deriveJSON)
+import Data.Aeson.Types (defaultOptions)
+import Language.Haskell.TH (Dec, Name, Q)
+
+defaultOptions' :: Options
+defaultOptions' = defaultOptions{fieldLabelModifier = camelTo2 '-'}
+
+deriveJSON :: Name -> Q [Dec]
+deriveJSON = TH.deriveJSON defaultOptions'

--- a/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
@@ -16,7 +16,7 @@ import Data.String (IsString (..))
 import Data.String.Interpolate (i)
 import Data.Yaml (decodeFileThrow)
 import Language.EO.Phi
-import Language.EO.Phi.Metrics (BindingsByPathMetrics (..), ProgramMetrics (..), getProgramMetrics)
+import Language.EO.Phi.Metrics (getProgramMetrics)
 import Language.EO.Phi.Rules.Common (Rule, defaultContext, equalProgram)
 import Language.EO.Phi.Rules.PhiPaper (rule1, rule6)
 import Test.EO.Phi

--- a/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
@@ -16,7 +16,7 @@ import Data.String (IsString (..))
 import Data.String.Interpolate (i)
 import Data.Yaml (decodeFileThrow)
 import Language.EO.Phi
-import Language.EO.Phi.Metrics (collectMetrics)
+import Language.EO.Phi.Metrics (BindingsByPathMetrics (..), ProgramMetrics (..), getProgramMetrics)
 import Language.EO.Phi.Rules.Common (Context (..), Rule, equalProgram)
 import Language.EO.Phi.Rules.PhiPaper (rule1, rule6)
 import Test.EO.Phi
@@ -57,7 +57,7 @@ spec = do
     metricsTests <- runIO $ decodeFileThrow @_ @MetricsTestSet "test/eo/phi/metrics.yaml"
     forM_ metricsTests.tests $ \test -> do
       it test.title $
-        collectMetrics (fromString @Program test.phi) `shouldBe` test.metrics
+        getProgramMetrics ["org", "eolang"] (fromString @Program test.phi) `shouldBe` Right test.metrics
 
 trim :: String -> String
 trim = dropWhileEnd isSpace

--- a/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
@@ -16,7 +16,7 @@ import Data.String (IsString (..))
 import Data.String.Interpolate (i)
 import Data.Yaml (decodeFileThrow)
 import Language.EO.Phi
-import Language.EO.Phi.Metrics.Collect (collectMetrics)
+import Language.EO.Phi.Metrics (collectMetrics)
 import Language.EO.Phi.Rules.Common (Context (..), Rule, equalProgram)
 import Language.EO.Phi.Rules.PhiPaper (rule1, rule6)
 import Test.EO.Phi

--- a/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/PhiSpec.hs
@@ -16,7 +16,7 @@ import Data.String (IsString (..))
 import Data.String.Interpolate (i)
 import Data.Yaml (decodeFileThrow)
 import Language.EO.Phi
-import Language.EO.Phi.Metrics (getProgramMetrics)
+import Language.EO.Phi.Metrics (BindingsByPathMetrics (..), ProgramMetrics (..), getProgramMetrics)
 import Language.EO.Phi.Rules.Common (Rule, defaultContext, equalProgram)
 import Language.EO.Phi.Rules.PhiPaper (rule1, rule6)
 import Test.EO.Phi
@@ -57,7 +57,7 @@ spec = do
     metricsTests <- runIO $ decodeFileThrow @_ @MetricsTestSet "test/eo/phi/metrics.yaml"
     forM_ metricsTests.tests $ \test -> do
       it test.title $
-        getProgramMetrics ["org", "eolang"] (fromString @Program test.phi) `shouldBe` Right test.metrics
+        getProgramMetrics (fromString @Program test.phi) ((.path) <$> test.metrics.bindingsByPathMetrics) `shouldBe` Right test.metrics
 
 trim :: String -> String
 trim = dropWhileEnd isSpace

--- a/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -231,7 +230,7 @@ defaultSearchLimits :: Int -> SearchLimits
 defaultSearchLimits = defaultApplicationLimits
 
 confluent :: [Rule] -> Property
-confluent rulesFromYaml = withMaxSuccess 1000 $
+confluent rulesFromYaml = withMaxSuccess 1_000 $
   forAllShrink (resize 40 $ genCriticalPair rulesFromYaml) (shrinkCriticalPair rulesFromYaml) $
     \pair@CriticalPair{..} ->
       within 100_000 $ -- 0.1 second timeout per test

--- a/eo-phi-normalizer/test/Test/Metrics/Phi.hs
+++ b/eo-phi-normalizer/test/Test/Metrics/Phi.hs
@@ -6,7 +6,7 @@ module Test.Metrics.Phi where
 
 import Data.Yaml (FromJSON)
 import GHC.Generics (Generic)
-import Language.EO.Phi.Metrics.Collect (Metrics)
+import Language.EO.Phi.Metrics.Collect (ProgramMetrics)
 
 data MetricsTestSet = MetricsTestSet
   { title :: String
@@ -17,6 +17,6 @@ data MetricsTestSet = MetricsTestSet
 data MetricsTest = MetricsTest
   { title :: String
   , phi :: String
-  , metrics :: Metrics
+  , metrics :: ProgramMetrics
   }
   deriving (Generic, FromJSON)

--- a/eo-phi-normalizer/test/Test/Metrics/Phi.hs
+++ b/eo-phi-normalizer/test/Test/Metrics/Phi.hs
@@ -6,7 +6,7 @@ module Test.Metrics.Phi where
 
 import Data.Yaml (FromJSON)
 import GHC.Generics (Generic)
-import Language.EO.Phi.Metrics.Collect (ProgramMetrics)
+import Language.EO.Phi.Metrics (ProgramMetrics)
 
 data MetricsTestSet = MetricsTestSet
   { title :: String

--- a/eo-phi-normalizer/test/eo/phi/metrics.yaml
+++ b/eo-phi-normalizer/test/eo/phi/metrics.yaml
@@ -37,15 +37,23 @@ tests:
       ⟧
     }
   metrics:
-    program:
-      dataless: 3
+    programMetrics:
+      dataless: 0
       applications: 8
       formations: 5
       dispatches: 24
-    attributes:
-      - name: org
-        metrics:
-          dataless: 2
-          applications: 8
-          formations: 4
-          dispatches: 24
+    bindingsByPathMetrics:
+      path: ['org', 'eolang']
+      bindingsMetrics:
+        - name: prints-itself
+          metrics:
+            dataless: 0
+            applications: 4
+            formations: 1
+            dispatches: 11
+        - name: prints-itself-to-console
+          metrics:
+            dataless: 0
+            applications: 4
+            formations: 1
+            dispatches: 13

--- a/eo-phi-normalizer/test/eo/phi/metrics.yaml
+++ b/eo-phi-normalizer/test/eo/phi/metrics.yaml
@@ -37,7 +37,15 @@ tests:
       ⟧
     }
   metrics:
-    dataless: 5
-    applications: 8
-    formations: 5
-    dispatches: 24
+    program:
+      dataless: 3
+      applications: 8
+      formations: 5
+      dispatches: 24
+    attributes:
+      - name: org
+        metrics:
+          dataless: 2
+          applications: 8
+          formations: 4
+          dispatches: 24

--- a/eo-phi-normalizer/test/eo/phi/metrics.yaml
+++ b/eo-phi-normalizer/test/eo/phi/metrics.yaml
@@ -37,14 +37,14 @@ tests:
       ⟧
     }
   metrics:
-    programMetrics:
+    program-metrics:
       dataless: 0
       applications: 8
       formations: 5
       dispatches: 24
-    bindingsByPathMetrics:
-      path: ['org', 'eolang']
-      bindingsMetrics:
+    bindings-by-path-metrics:
+      path: org.eolang
+      bindings-metrics:
         - name: prints-itself
           metrics:
             dataless: 0

--- a/scripts/metrics.sh
+++ b/scripts/metrics.sh
@@ -1,0 +1,27 @@
+set -euo pipefail
+shopt -s extglob
+
+cd pipeline
+
+function collect_metrics {
+    printf "\nCollecting metrics for PHI$3\n\n"
+
+    METRICS_DIR="$1"
+
+    mkdir -p "$METRICS_DIR"
+
+    cd "$2"
+
+    PHI_FILES="$(find . -wholename '*.phi' -not -path './.eoc/**')"
+
+    for phi_file in $PHI_FILES; do
+        phi_metrics_file_name="${phi_file%.phi}.json"
+        destination="../$METRICS_DIR/$phi_metrics_file_name"
+        stack run -- metrics "$phi_file" --program-path "org.eolang" > "$destination"
+    done
+
+    cd ..
+}
+
+collect_metrics "metrics/phi" "phi" ""
+collect_metrics "metrics/phi-normalized" "phi-normalized" " normalized"

--- a/site/docs/src/commands/normalizer-metrics.md
+++ b/site/docs/src/commands/normalizer-metrics.md
@@ -48,6 +48,7 @@ normalizer metrics --help
 
 ```console
 Usage: normalizer metrics [FILE] [-o|--output-file FILE]
+                          [-b|--bindings-by-path PATH]
 
   Collect metrics for a PHI program.
 
@@ -56,6 +57,10 @@ Available options:
                            read from stdin.
   -o,--output-file FILE    Output to FILE. When this option is not specified,
                            output to stdout.
+  -b,--bindings-by-path PATH
+                           Report metrics for bindings of a formation accessible
+                           in a program by a PATH. The default PATH is empty.
+                           Example of a PATH: 'org.eolang'.
   -h,--help                Show this help text
 ```
 
@@ -67,10 +72,26 @@ normalizer metrics program.phi
 
 ```json
 {
-  "applications": 1,
-  "dataless": 5,
-  "dispatches": 5,
-  "formations": 5
+  "bindingsByPathMetrics": {
+    "bindingsMetrics": [
+      {
+        "metrics": {
+          "applications": 1,
+          "dataless": 1,
+          "dispatches": 4,
+          "formations": 4
+        },
+        "name": "a"
+      }
+    ],
+    "path": []
+  },
+  "programMetrics": {
+    "applications": 1,
+    "dataless": 1,
+    "dispatches": 4,
+    "formations": 5
+  }
 }
 ```
 
@@ -82,10 +103,26 @@ cat program.phi | normalizer metrics
 
 ```json
 {
-  "applications": 1,
-  "dataless": 5,
-  "dispatches": 5,
-  "formations": 5
+  "bindingsByPathMetrics": {
+    "bindingsMetrics": [
+      {
+        "metrics": {
+          "applications": 1,
+          "dataless": 1,
+          "dispatches": 4,
+          "formations": 4
+        },
+        "name": "a"
+      }
+    ],
+    "path": []
+  },
+  "programMetrics": {
+    "applications": 1,
+    "dataless": 1,
+    "dispatches": 4,
+    "formations": 5
+  }
 }
 ```
 
@@ -93,4 +130,40 @@ cat program.phi | normalizer metrics
 
 ```$ as console
 normalizer metrics --bindings-by-path "a" program.phi
+```
+
+```console
+{
+  "bindingsByPathMetrics": {
+    "bindingsMetrics": [
+      {
+        "metrics": {
+          "applications": 0,
+          "dataless": 0,
+          "dispatches": 2,
+          "formations": 2
+        },
+        "name": "b"
+      },
+      {
+        "metrics": {
+          "applications": 1,
+          "dataless": 1,
+          "dispatches": 2,
+          "formations": 1
+        },
+        "name": "e"
+      }
+    ],
+    "path": [
+      "a"
+    ]
+  },
+  "programMetrics": {
+    "applications": 1,
+    "dataless": 1,
+    "dispatches": 4,
+    "formations": 5
+  }
+}
 ```

--- a/site/docs/src/commands/normalizer-metrics.md
+++ b/site/docs/src/commands/normalizer-metrics.md
@@ -88,3 +88,9 @@ cat program.phi | normalizer metrics
   "formations": 5
 }
 ```
+
+### `--bindings-by-path`
+
+```$ as console
+normalizer metrics --bindings-by-path "a" program.phi
+```

--- a/site/docs/src/commands/normalizer-transform.md
+++ b/site/docs/src/commands/normalizer-transform.md
@@ -104,10 +104,10 @@ normalizer transform --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor.yaml pr
 ```console
 Rule set based on Yegor's draft
 Input:
-{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧.e ⟧ }
+{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }
 ====================================================
 Result 1 out of 1:
-{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧ }
+{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }
 ----------------------------------------------------
 ```
 
@@ -122,11 +122,10 @@ normalizer transform --chain --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor
 ```console
 Rule set based on Yegor's draft
 Input:
-{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧.e ⟧ }
+{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }
 ====================================================
 Result 1 out of 1:
-[ 1 / 2 ]{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧.e ⟧ }
-[ 2 / 2 ]{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧ }
+[ 1 / 1 ]{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }
 ----------------------------------------------------
 ```
 
@@ -138,12 +137,9 @@ normalizer transform --json --chain --rules ./eo-phi-normalizer/test/eo/phi/rule
 
 ```json
 {
-  "input": "{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧.e ⟧ }",
+  "input": "{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }",
   "output": [
-    [
-      "{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧.e ⟧ }",
-      "{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧ }"
-    ]
+    ["{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }"]
   ]
 }
 ```
@@ -155,7 +151,7 @@ normalizer transform --single --rules ./eo-phi-normalizer/test/eo/phi/rules/yego
 ```
 
 ```console
-{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧ }
+{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }
 ```
 
 ### `--single` `--json`
@@ -165,7 +161,7 @@ normalizer transform --single --json --rules ./eo-phi-normalizer/test/eo/phi/rul
 ```
 
 ```console
-"{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧ }"
+"{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }"
 ```
 
 ### `FILE` not specified (read from stdin)
@@ -175,5 +171,5 @@ cat program.phi | normalizer transform --single --json --rules ./eo-phi-normaliz
 ```
 
 ```console
-"{ ⟦ a ↦ ξ.b (c ↦ ⟦ ⟧).d (ρ ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧ ⟧) ⟧ }"
+"{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }"
 ```

--- a/site/docs/src/commands/normalizer.md
+++ b/site/docs/src/commands/normalizer.md
@@ -17,4 +17,5 @@ Available options:
 Available commands:
   transform                Transform a PHI program.
   metrics                  Collect metrics for a PHI program.
+  dataize                  Dataize a PHI program.
 ```

--- a/site/docs/src/common/sample-program.md
+++ b/site/docs/src/common/sample-program.md
@@ -13,7 +13,7 @@ cat > program.phi <<EOM
               d ↦ ⟦ φ ↦ ξ.ρ.c ⟧
             ⟧,
         e ↦ ξ.b(c ↦ ⟦⟧).d
-      ⟧.e
+      ⟧
   ⟧
 }
 EOM


### PR DESCRIPTION
Based on #193
Closes #204, #210

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `dataize` functionality, refactors `Metrics`, updates test files, and enhances YAML handling.

### Detailed summary
- Added `dataize` functionality to PHI program
- Refactored `Metrics` structure and added JSON serialization
- Updated test files and imports
- Enhanced YAML handling for metrics collection

> The following files were skipped due to too many changes: `eo-phi-normalizer/src/Language/EO/Phi/Metrics.hs`, `eo-phi-normalizer/app/Main.hs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->