### PR TITLE
fix(vscode settings): use external fourmolu

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "haskell.formattingProvider": "fourmolu",
+  "haskell.plugin.fourmolu.config.external": true,
   "[haskell]": {
     "editor.defaultFormatter": "haskell.haskell"
   },


### PR DESCRIPTION
Closes #214 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling external configuration for the `fourmolu` formatting provider in VS Code settings.

### Detailed summary
- Enabled external configuration for `fourmolu` formatting provider in VS Code settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->