### PR TITLE
Improve the docs job, improve the site, fix minor errors

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -151,24 +151,24 @@ jobs:
         with:
           mdbook-version: "latest"
 
-      - name: Build site
+      - name: Add haddock
         run: |
-          ROOT=$PWD
-
           mkdir -p dist/haddock
           mv $(stack path --local-doc-root)/* dist/haddock
 
+      - name: Add docs
+        run: |
           cd site/docs
           mdbook build
           mv docs ../../dist
-          cd ../..
 
-          cd site
-          mv index.html ../dist
-          cd ..
-
+      - name: Add report
+        run: |
           mkdir -p dist/report
           cp report/report.html dist/report/index.html
+
+      - name: Add index.html
+        run: mv site/index.html dist
 
       - name: 🚀 Publish Site
         uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -137,7 +137,7 @@ jobs:
         uses: deemp/stack-action@main
         with:
           test: false
-          stack-build-arguments: --fast --haddock
+          stack-build-arguments: --fast --haddock --copy-bins
           cache-prefix: docs-
 
       - name: Download pipeline artifact

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -171,6 +171,21 @@ jobs:
       - name: Run mdsh
         run: ./scripts/run-mdsh.sh
 
+      - name: Configure git for github-actions
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Commit changes produced by mdsh
+        run: |
+          git pull --rebase --autostash
+
+          git add site
+
+          git commit -m "Run mdsh" \
+            && git push \
+            || true
+
       - name: Add docs
         run: |
           cd site/docs

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -138,6 +138,7 @@ jobs:
         with:
           test: false
           stack-build-arguments: --fast --haddock
+          cache-prefix: docs-
 
       - name: Download pipeline artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -151,10 +151,25 @@ jobs:
         with:
           mdbook-version: "latest"
 
+      - name: cargo-install
+        uses: baptiste0928/cargo-install@v3.0.1
+        with:
+          crate: mdsh
+          git: https://github.com/zimbatm/mdsh
+          tag: v0.8.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
       - name: Add haddock
         run: |
           mkdir -p dist/haddock
           mv $(stack path --local-doc-root)/* dist/haddock
+
+      - name: Run mdsh
+        run: ./scripts/run-mdsh.sh
 
       - name: Add docs
         run: |

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -68,6 +68,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
 
       - uses: actions/setup-java@v4
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+eo
+report

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -5,7 +5,7 @@ github: "objectionary/eo-phi-normalizer"
 license: BSD3
 author: "EO/Polystat Development Team"
 maintainer: "nickolay.kudasov@gmail.com"
-copyright: "2023 EO/Polystat Development Team"
+copyright: "2023-2024 EO/Polystat Development Team"
 
 extra-source-files:
   - README.md

--- a/flake.nix
+++ b/flake.nix
@@ -173,27 +173,45 @@
           mdsh = {
             runtimeInputs = [
               mdsh
-              pkgs.nodePackages.prettier
               stack
             ];
-            text = ''
-              export LC_ALL=C.UTF-8
-              mdsh
-              # create sample program
-              mdsh -i site/docs/src/common/sample-program.md --work_dir .
-              # run commands on it
+            text =
+              let text =
+                ''
+                  mdsh
 
-              ${lib.concatMapStringsSep "\n"
-                (x: "mdsh -i site/docs/src/${x} --work_dir .")
-                [
-                  "commands/normalizer.md"
-                  "commands/normalizer-transform.md"
-                  "commands/normalizer-metrics.md"
-                  "contributing.md"
-                ]
-              }
-              prettier -w "**/*.md"
-            '';
+                  ${lib.concatMapStringsSep "\n"
+                    (x: "mdsh -i site/docs/src/${x} --work_dir .")
+                    [
+                      "common/sample-program.md"
+                      "common/celsius.md"
+                      "commands/normalizer.md"
+                      "commands/normalizer-transform.md"
+                      "commands/normalizer-metrics.md"
+                      "commands/normalizer-dataize.md"
+                      "commands/normalizer-report.md"
+                      "contributing.md"
+                    ]
+                  }
+
+                  rm program.phi celsius.phi
+
+                  npm i
+                  npx prettier -w "**/*.md"
+                '';
+              in
+                ''
+                export LC_ALL=C.UTF-8
+                stack install
+
+                cat << EOF > scripts/run-mdsh.sh
+                ${text}
+                EOF
+
+                chmod +x scripts/run-mdsh.sh
+
+                ${text}
+                '';
           };
         };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
     "packages": {
         "": {
             "devDependencies": {
-                "eolang": "^0.18.0"
+                "eolang": "^0.18.0",
+                "prettier": "^3.2.5"
             }
         },
         "node_modules/@types/concat-stream": {
@@ -442,6 +443,21 @@
             "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
             "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
             "dev": true
+        },
+        "node_modules/prettier": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "devDependencies": {
-        "eolang": "^0.18.0"
+        "eolang": "^0.18.0",
+        "prettier": "^3.2.5"
     }
 }

--- a/scripts/run-mdsh.sh
+++ b/scripts/run-mdsh.sh
@@ -1,0 +1,16 @@
+mdsh
+
+mdsh -i site/docs/src/common/sample-program.md --work_dir .
+mdsh -i site/docs/src/common/celsius.md --work_dir .
+mdsh -i site/docs/src/commands/normalizer.md --work_dir .
+mdsh -i site/docs/src/commands/normalizer-transform.md --work_dir .
+mdsh -i site/docs/src/commands/normalizer-metrics.md --work_dir .
+mdsh -i site/docs/src/commands/normalizer-dataize.md --work_dir .
+mdsh -i site/docs/src/commands/normalizer-report.md --work_dir .
+mdsh -i site/docs/src/contributing.md --work_dir .
+
+rm program.phi celsius.phi
+
+npm i
+npx prettier -w "**/*.md"
+

--- a/site/docs/book.toml
+++ b/site/docs/book.toml
@@ -9,6 +9,8 @@ title = "phi-normalizer"
 additional-css = ["theme/pagetoc.css"]
 additional-js = ["theme/pagetoc.js"]
 mathjax-support = true
+git-repository-url = "https://github.com/objectionary/normalizer"
+git-repository-icon = "fa-github"
 
 [build]
 build-dir = "./docs"

--- a/site/docs/src/commands/normalizer-dataize.md
+++ b/site/docs/src/commands/normalizer-dataize.md
@@ -17,30 +17,11 @@ Then, a single step of dataization is performed according to the following rules
 
 The full dataization process is achieved by recursively normalizing and dataizing according to the rules above until bytes are reached or the object does not change (in which case the dataization is considered to have failed).
 
+## Environment
+
+{{#include ../common/celsius.md}}
+
 ## CLI
-
-The examples in the following sections assume the existence a file `celsius.phi` with the following content:
-
-```
-{⟦
-  σ ↦ Φ,
-  c ↦ Φ.org.eolang.float(Δ ⤍ 19-), // 0x19 = 25
-  // The 02- should technically be 1.8 (or its float representation in bytes), but only integers are supported for now
-  φ ↦ ξ.c.times(α0 ↦ ⟦ Δ ⤍ 02- ⟧)
-          .plus(α0 ↦ ⟦ Δ ⤍ 20- ⟧), // 0x20 = 32
-  org ↦ ⟦
-    eolang ↦ ⟦
-      float ↦ ⟦
-        Δ ⤍ ∅,
-        times ↦ ⟦ α0 ↦ ∅, λ ⤍ Times ⟧,
-        plus ↦ ⟦ α0 ↦ ∅, λ ⤍ Plus ⟧
-      ⟧
-    ⟧
-  ⟧
-⟧}
-```
-
-Dataization is done using the `dataize` subcommand, and it supports the following arguments:
 
 ### `--help`
 

--- a/site/docs/src/commands/normalizer-transform.md
+++ b/site/docs/src/commands/normalizer-transform.md
@@ -10,7 +10,7 @@ See the `MetaPHI` [Labelled BNF](https://bnfc.readthedocs.io/en/latest/lbnf.html
 
 Currently, the `PHI` normalizer supports rules defined in an unpublished paper by Yegor Bugayenko.
 
-![Rules](media/rules.jpg)
+![Rules](../media/rules.jpg)
 
 ### yegor.yaml
 

--- a/site/docs/src/common/celsius.md
+++ b/site/docs/src/common/celsius.md
@@ -1,0 +1,23 @@
+Save a `PHI` program to a file.
+This program will be used in subsequent commands.
+
+```$
+cat > celsius.phi <<EOM
+{⟦
+  σ ↦ Φ,
+  c ↦ Φ.org.eolang.float(Δ ⤍ 19-), // 0x19 = 25
+  // The 02- should technically be 1.8 (or its float representation in bytes), but only integers are supported for now
+  φ ↦ ξ.c.times(α0 ↦ ⟦ Δ ⤍ 02- ⟧)
+          .plus(α0 ↦ ⟦ Δ ⤍ 20- ⟧), // 0x20 = 32
+  org ↦ ⟦
+    eolang ↦ ⟦
+      float ↦ ⟦
+        Δ ⤍ ∅,
+        times ↦ ⟦ α0 ↦ ∅, λ ⤍ Times ⟧,
+        plus ↦ ⟦ α0 ↦ ∅, λ ⤍ Plus ⟧
+      ⟧
+    ⟧
+  ⟧
+⟧}
+EOM
+```

--- a/site/docs/src/contributing.md
+++ b/site/docs/src/contributing.md
@@ -64,6 +64,26 @@ stack test
 
 Use the syntax supported by `mdBook` - see [docs](https://rust-lang.github.io/mdBook/format/mathjax.html).
 
+## Docs
+
+### mdsh
+
+We use [mdsh](https://github.com/zimbatm/mdsh) to document command outputs (see [Multiline Shell Code](https://github.com/zimbatm/mdsh#multiline-shell-code)).
+
+You can install `mdsh` via `cargo` or `nix` ([link](https://github.com/zimbatm/mdsh#installation)).
+
+### prettier
+
+We format docs with [prettier](https://prettier.io/).
+
+Run `npm i` to locally install the `prettier` version that we use.
+
+### Automatic updates
+
+In CI, on the `master` branch, we run [scripts/run-mdsh](https://github.com/objectionary/normalizer/blob/master/scripts/run-mdsh.sh) and commit changes.
+
+So, no worries if you haven't run `mdsh` in your PR!
+
 ## pre-commit
 
 We use [pre-commit](https://pre-commit.com/) to ensure code quality.

--- a/site/docs/src/installation.md
+++ b/site/docs/src/installation.md
@@ -17,7 +17,7 @@ stack install normalizer
 ```sh
 stack update
 export LC_ALL=C.UTF-8
-stack install --resolver lts-22.11 eo-phi-normalizer
+stack install --resolver lts-22.6 eo-phi-normalizer
 ```
 
 ## Uninstall

--- a/site/docs/src/introduction.md
+++ b/site/docs/src/introduction.md
@@ -5,3 +5,9 @@ Command line normalizer of 𝜑-calculus (`PHI`) expressions (as produced by the
 This project aims to apply term rewriting techniques to "simplify" an input `PHI` expression and prepare it for further optimization passes. The simplification procedure will be a form of partial evaluation and normalization (see [normalizer transform](./commands/normalizer-transform.md)).
 
 Contrary to traditional normalization in λ-calculus, we aim at rewriting rules that would help reduce certain metrics of expressions (see [normalizer metrics](./commands/normalizer-metrics.md)).
+
+See the [report](https://www.objectionary.com/normalizer/report) on our current progress with metrics.
+
+The normalizer package is available on [Hackage](https://hackage.haskell.org/package/eo-phi-normalizer).
+
+The latest package [Haddock documentation](https://www.objectionary.com/normalizer/haddock) is available on our site.


### PR DESCRIPTION
## Changes

- closes #179
- closes #182
- refactor normalizer-dataize docs a bit
- add links to report, Hackage package, haddock docs
- update copyright in `package.yaml`
- fix resolver version in docs
- add the docs section in the contributing guide

## TODO

- [ ] Document that mdsh runs automatically

## Rendered site

https://deemp.github.io/normalizer

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to add `prettier`, update dependencies, enhance documentation, and automate formatting.

### Detailed summary
- Added `prettier` dependency
- Updated `eo-phi-normalizer` resolver to lts-22.6
- Added GitHub repository URL and icon
- Updated `copyright` in `package.yaml`
- Improved `celsius.md` with a new program example
- Enhanced documentation with links and content
- Added `mdsh` script for document generation
- Automated formatting with `prettier` on Markdown files

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->