### PR TITLE
fix(normalizer): rename VTX -> Vertex

### DIFF
--- a/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
+++ b/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
@@ -37,7 +37,7 @@ separator Binding "," ;
 Phi.    Attribute ::= "φ" ;   -- decoratee object
 Rho.    Attribute ::= "ρ" ;   -- parent object
 Sigma.  Attribute ::= "σ" ;   -- home object
-VTX.    Attribute ::= "ν" ;   -- the vertex identifier (an object that represents the unique identifier of the containing object)
+Vertex.    Attribute ::= "ν" ;   -- the vertex identifier (an object that represents the unique identifier of the containing object)
 Label.  Attribute ::= LabelId ;
 Alpha.  Attribute ::= AlphaIndex ;
 MetaAttr. Attribute ::= MetaId ;

--- a/eo-phi-normalizer/src/Language/EO/Phi/Normalize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Normalize.hs
@@ -27,8 +27,8 @@ data Context = Context
   deriving (Generic)
 
 isNu :: Binding -> Bool
-isNu (AlphaBinding VTX _) = True
-isNu (EmptyBinding VTX) = True
+isNu (AlphaBinding Vertex _) = True
+isNu (EmptyBinding Vertex) = True
 isNu _ = False
 
 -- | Normalize an input 𝜑-program.
@@ -46,7 +46,7 @@ rule1 :: Object -> State Context Object
 rule1 (Formation bindings) = do
   normalizedBindings <- forM bindings $ \case
     AlphaBinding a object
-      | a /= VTX ->
+      | a /= Vertex ->
           do
             object' <- rule1 object
             pure (AlphaBinding a object')
@@ -57,7 +57,7 @@ rule1 (Formation bindings) = do
         #maxNu += 1
         nus <- gets maxNu
         let dataObject = intToBytesObject nus
-        pure (AlphaBinding VTX dataObject : normalizedBindings)
+        pure (AlphaBinding Vertex dataObject : normalizedBindings)
       else do
         pure normalizedBindings
   pure (Formation finalBindings)

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -212,7 +212,7 @@ equalBindings bindings1 bindings2 = and (zipWith equalBinding (sortOn attr bindi
   attr (MetaBindings metaId) = MetaAttr metaId
 
 equalBinding :: Binding -> Binding -> Bool
-equalBinding (AlphaBinding VTX _) (AlphaBinding VTX _) = True -- TODO #166:15min Renumerate vertices uniformly instead of ignoring them
+equalBinding (AlphaBinding Vertex _) (AlphaBinding Vertex _) = True -- TODO #166:15min Renumerate vertices uniformly instead of ignoring them
 equalBinding (AlphaBinding attr1 obj1) (AlphaBinding attr2 obj2) = attr1 == attr2 && equalObject obj1 obj2
 -- Ignore deltas for now while comparing since different normalization paths can lead to different vertex data
 -- TODO #120:30m normalize the deltas instead of ignoring since this actually suppresses problems
@@ -296,7 +296,7 @@ instance HasMaxNu Object where
 instance HasMaxNu Binding where
   getMaxNu :: Binding -> Int
   getMaxNu = \case
-    AlphaBinding VTX (Formation [DeltaBinding (Bytes bs)]) ->
+    AlphaBinding Vertex (Formation [DeltaBinding (Bytes bs)]) ->
       case readHex [x | x <- bs, x /= '-'] of
         [(val, "")] -> val
         _ -> error "Vertex number is incorrect"

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -146,7 +146,7 @@ attrHasMetavars :: Attribute -> Bool
 attrHasMetavars Phi = False
 attrHasMetavars Rho = False
 attrHasMetavars Sigma = False
-attrHasMetavars VTX = False
+attrHasMetavars Vertex = False
 attrHasMetavars (Label _) = False
 attrHasMetavars (Alpha _) = False
 attrHasMetavars (MetaAttr _) = True
@@ -291,7 +291,7 @@ matchObject _ _ = [] -- ? emptySubst ?
 -- and an object
 --
 -- >>> evaluateMetaFuncs "⟦ a ↦ ⟦ ν ↦ ⟦ Δ ⤍ 03- ⟧ ⟧, b ↦ ⟦ ⟧ ⟧" "⟦ a ↦ ⟦ ν ↦ @T(⟦ a ↦ ⟦ ν ↦ ⟦ Δ ⤍ 03- ⟧ ⟧, b ↦ ⟦ ⟧ ⟧)  ⟧, b ↦ ⟦ ⟧ ⟧"
--- Formation [AlphaBinding (Label (LabelId "a")) (Formation [AlphaBinding VTX (Formation [DeltaBinding (Bytes "04-")])]),AlphaBinding (Label (LabelId "b")) (Formation [])]
+-- Formation [AlphaBinding (Label (LabelId "a")) (Formation [AlphaBinding Vertex (Formation [DeltaBinding (Bytes "04-")])]),AlphaBinding (Label (LabelId "b")) (Formation [])]
 evaluateMetaFuncs :: Object -> Object -> Object
 evaluateMetaFuncs obj' obj =
   evalState

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
@@ -43,7 +43,7 @@ data Attribute
     = Phi
     | Rho
     | Sigma
-    | VTX
+    | Vertex
     | Label LabelId
     | Alpha AlphaIndex
     | MetaAttr MetaId

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
@@ -124,7 +124,7 @@ Attribute
   : 'φ' { Language.EO.Phi.Syntax.Abs.Phi }
   | 'ρ' { Language.EO.Phi.Syntax.Abs.Rho }
   | 'σ' { Language.EO.Phi.Syntax.Abs.Sigma }
-  | 'ν' { Language.EO.Phi.Syntax.Abs.VTX }
+  | 'ν' { Language.EO.Phi.Syntax.Abs.Vertex }
   | LabelId { Language.EO.Phi.Syntax.Abs.Label $1 }
   | AlphaIndex { Language.EO.Phi.Syntax.Abs.Alpha $1 }
   | MetaId { Language.EO.Phi.Syntax.Abs.MetaAttr $1 }

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
@@ -184,7 +184,7 @@ instance Print Language.EO.Phi.Syntax.Abs.Attribute where
     Language.EO.Phi.Syntax.Abs.Phi -> prPrec i 0 (concatD [doc (showString "\966")])
     Language.EO.Phi.Syntax.Abs.Rho -> prPrec i 0 (concatD [doc (showString "\961")])
     Language.EO.Phi.Syntax.Abs.Sigma -> prPrec i 0 (concatD [doc (showString "\963")])
-    Language.EO.Phi.Syntax.Abs.VTX -> prPrec i 0 (concatD [doc (showString "\957")])
+    Language.EO.Phi.Syntax.Abs.Vertex -> prPrec i 0 (concatD [doc (showString "\957")])
     Language.EO.Phi.Syntax.Abs.Label labelid -> prPrec i 0 (concatD [prt 0 labelid])
     Language.EO.Phi.Syntax.Abs.Alpha alphaindex -> prPrec i 0 (concatD [prt 0 alphaindex])
     Language.EO.Phi.Syntax.Abs.MetaAttr metaid -> prPrec i 0 (concatD [prt 0 metaid])

--- a/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
@@ -36,7 +36,7 @@ instance Arbitrary Attribute where
       [ pure Phi
       , pure Rho
       , pure Sigma
-      , pure VTX
+      , pure Vertex
       , Label <$> arbitrary
       ]
 
@@ -61,7 +61,7 @@ instance Arbitrary Binding where
       , do
           attr <- arbitrary
           obj <- case attr of
-            VTX ->
+            Vertex ->
               Formation <$> do
                 bytes <- arbitrary
                 return [DeltaBinding bytes]
@@ -71,7 +71,7 @@ instance Arbitrary Binding where
       , LambdaBinding <$> arbitrary
       , pure DeltaEmptyBinding
       ]
-  shrink (AlphaBinding VTX _) = [] -- do not shrink vertex bindings
+  shrink (AlphaBinding Vertex _) = [] -- do not shrink vertex bindings
   shrink (AlphaBinding attr obj) = AlphaBinding attr <$> shrink obj
   shrink _ = [] -- do not shrink deltas and lambdas
 


### PR DESCRIPTION
- Closes #42

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates identifiers in the EO Phi syntax from `VTX` to `Vertex` for consistency and clarity.

### Detailed summary
- Renamed `VTX` to `Vertex` in multiple files for consistency.
- Updated corresponding functions and rules to reflect the identifier change.
- Improved clarity and maintainability of the codebase.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->