### PR TITLE
Fix hlint warnings

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -65,7 +65,11 @@
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
 - ignore:
     name: Unused LANGUAGE pragma
-    within: Language.EO.Phi.Metrics
+    within: [Language.EO.Phi.Metrics.Collect, Language.EO.Phi.Normalize]
+
+- ignore:
+    name: Redundant pure
+    within: Language.EO.Phi.Rules.Yaml
 
 # Define some custom infix operators
 # - fixity: infixr 3 ~^#^~

--- a/eo-phi-normalizer/Setup.hs
+++ b/eo-phi-normalizer/Setup.hs
@@ -19,7 +19,7 @@ main = defaultMainWithHooks $ simpleUserHooks
   { hookedPrograms = [ bnfcProgram ]
   , postConf       = \args flags packageDesc localBuildInfo -> do
 #ifndef mingw32_HOST_OS
-      _ <- system $ [i|
+      _ <- system [i|
             bnfc --haskell -d -p Language.EO.Phi --generic -o src/ grammar/EO/Phi/Syntax.cf
             cd src/Language/EO/Phi/Syntax
             alex Lex.x

--- a/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/Rules/PhiPaperSpec.hs
@@ -86,7 +86,7 @@ instance Arbitrary Object where
         arbitraryBindings = List.nubBy sameAttr <$> listOf arbitraryBinding
         arbitraryAlphaLabelBinding =
           resize (n `div` 2) $
-            AlphaBinding <$> (Label <$> arbitrary) <*> arbitrary
+            (AlphaBinding . Label <$> arbitrary) <*> arbitrary
         arbitraryAlphaLabelBindings = List.nubBy sameAttr <$> listOf arbitraryAlphaLabelBinding
     if n > 0
       then

--- a/eo-phi-normalizer/test/Language/EO/YamlSpec.hs
+++ b/eo-phi-normalizer/test/Language/EO/YamlSpec.hs
@@ -22,4 +22,4 @@ spec = describe "User-defined rules unit tests" do
                 resultOneStep = applyOneRule (defaultContext [rule'] ruleTest.input) ruleTest.input
                 expected = ruleTest.output
                 sameObjs objs1 objs2 = and ((length objs1 == length objs2) : zipWith equalObject objs2 objs1)
-             in (map snd resultOneStep) `shouldSatisfy` sameObjs expected
+             in map snd resultOneStep `shouldSatisfy` sameObjs expected


### PR DESCRIPTION
Apply `hlint` hints, or ignore them in `.hlint.yaml`

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update the Phi normalizer codebase. 

### Detailed summary
- Updated BNFC command in `Setup.hs`
- Modified HLint settings in `Setup.hs`
- Changed comparison in `YamlSpec.hs`
- Refactored code in `PhiPaperSpec.hs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->