### PR TITLE
Add --dependency-file option to support dependency files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 eo-phi-normalizer/src/Language/EO/Phi/Syntax/* linguist-generated=true
+eo-phi-normalizer/test/eo/phi/org/eolang/* linguist-generated=true

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -408,7 +408,12 @@ mergeBindings xs ys
           ]
 
 deepMerge :: Program -> Program -> Either String Program
-deepMerge (Program xs) (Program ys) = Program <$> mergeBindings xs ys
+deepMerge (Program xs) (Program ys) = Program <$> mergeBindings (mkPackage xs) (mkPackage ys)
+ where
+  mkPackage bs
+    | isPackage bs = bs
+    -- FIXME: check if lambda attribute exists and throw error!
+    | otherwise = LambdaBinding (Function "Package") : bs
 
 deepMergePrograms :: [Program] -> Either String Program
 deepMergePrograms [] = Right (Program [])

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -37,7 +37,6 @@ import Data.String.Interpolate (i, iii)
 import Data.Text.Internal.Builder (toLazyText)
 import Data.Text.Lazy as TL (unpack)
 import Data.Yaml (decodeFileThrow)
-import Debug.Trace (trace)
 import GHC.Generics (Generic)
 import Language.EO.Phi (AlphaIndex (AlphaIndex), Attribute (Alpha), Binding (..), Bytes (Bytes), Function (..), Object (Formation), Program (Program), parseProgram, printTree)
 import Language.EO.Phi.Dataize
@@ -382,8 +381,7 @@ isPackageBinding _ = False
 
 mergeBinding :: Binding -> Binding -> Either String Binding
 mergeBinding (AlphaBinding a (Formation xs)) (AlphaBinding b (Formation ys))
-  | a == b =
-      trace ("Merging under " <> printTree a) $ AlphaBinding a . Formation <$> mergeBindings xs ys
+  | a == b = AlphaBinding a . Formation <$> mergeBindings xs ys
 mergeBinding x y | x == y = return x
 mergeBinding x y =
   Left $

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -26,7 +26,7 @@
 
 module Main (main) where
 
-import Control.Monad (forM, unless, when)
+import Control.Monad (foldM, forM, unless, when)
 import Data.Foldable (forM_)
 
 import Control.Exception (Exception (..), SomeException, catch, throw)
@@ -37,8 +37,9 @@ import Data.String.Interpolate (i, iii)
 import Data.Text.Internal.Builder (toLazyText)
 import Data.Text.Lazy as TL (unpack)
 import Data.Yaml (decodeFileThrow)
+import Debug.Trace (trace)
 import GHC.Generics (Generic)
-import Language.EO.Phi (Bytes (Bytes), Object (Formation), Program (Program), parseProgram, printTree)
+import Language.EO.Phi (AlphaIndex (AlphaIndex), Attribute (Alpha), Binding (..), Bytes (Bytes), Function (..), Object (Formation), Program (Program), parseProgram, printTree)
 import Language.EO.Phi.Dataize
 import Language.EO.Phi.Metrics.Collect as Metrics (getProgramMetrics)
 import Language.EO.Phi.Metrics.Data as Metrics (ProgramMetrics (..), splitPath)
@@ -60,6 +61,7 @@ data CLI'TransformPhi = CLI'TransformPhi
   , single :: Bool
   , json :: Bool
   , inputFile :: Maybe FilePath
+  , dependencies :: [FilePath]
   , maxDepth :: Int
   , maxGrowthFactor :: Int
   }
@@ -68,6 +70,7 @@ data CLI'TransformPhi = CLI'TransformPhi
 data CLI'DataizePhi = CLI'DataizePhi
   { rulesPath :: String
   , inputFile :: Maybe FilePath
+  , dependencies :: [FilePath]
   , outputFile :: Maybe String
   , recursive :: Bool
   , chain :: Bool
@@ -140,6 +143,11 @@ outputFileOption = optional $ strOption (long "output-file" <> short 'o' <> meta
 inputFileArg :: Parser (Maybe String)
 inputFileArg = optional $ strArgument (metavar.file <> help [i|#{fileMetavarName} to read input from. When no #{fileMetavarName} is specified, read from stdin.|])
 
+dependenciesArg :: Parser [FilePath]
+dependenciesArg =
+  many $
+    strOption (long "dependency-file" <> short 'd' <> metavar.file <> help [i|#{fileMetavarName} to read dependencies from (zero or more dependency files allowed).|])
+
 jsonSwitch :: Parser Bool
 jsonSwitch = switch (long "json" <> short 'j' <> help "Output JSON.")
 
@@ -191,10 +199,12 @@ commandParser =
       let maxValue = 10
        in option auto (long "max-growth-factor" <> metavar.int <> value maxValue <> help [i|The factor by which to allow the input term to grow before stopping. Defaults to #{maxValue}.|])
     inputFile <- inputFileArg
+    dependencies <- dependenciesArg
     pure CLI'TransformPhi{..}
   dataize = do
     rulesPath <- strOption (long "rules" <> short 'r' <> metavar.file <> help [i|#{fileMetavarName} with user-defined rules. Must be specified.|])
     inputFile <- inputFileArg
+    dependencies <- dependenciesArg
     outputFile <- outputFileOption
     recursive <- switch (long "recursive" <> help "Apply dataization + normalization recursively.")
     chain <- switch (long "chain" <> help "Display all the intermediate steps.")
@@ -270,6 +280,7 @@ data CLI'Exception
   | CouldNotRead {message :: String}
   | CouldNotParse {message :: String}
   | CouldNotNormalize
+  | CouldNotMergeDependencies {message :: String}
   | Impossible {message :: String}
   deriving anyclass (Exception)
 
@@ -281,6 +292,7 @@ instance Show CLI'Exception where
     CouldNotRead{..} -> [i|Could not read the program:\n#{message}|]
     CouldNotParse{..} -> [i|An error occurred when parsing the input program:\n#{message}|]
     CouldNotNormalize -> [i|Could not normalize the program.|]
+    CouldNotMergeDependencies{..} -> message
     Impossible{..} -> message
 
 getFile :: Maybe FilePath -> IO (Maybe String)
@@ -335,6 +347,77 @@ getMetrics bindingsPath inputFile = do
   program <- getProgram inputFile
   either throw pure (getMetrics' program bindingsPath)
 
+-- ** Merging programs with dependencies
+
+bindingAttr :: Binding -> Maybe Attribute
+bindingAttr (AlphaBinding a _) = Just a
+bindingAttr (EmptyBinding a) = Just a
+bindingAttr (DeltaBinding _) = Just (Alpha (AlphaIndex "Δ"))
+bindingAttr DeltaEmptyBinding = Just (Alpha (AlphaIndex "Δ"))
+bindingAttr LambdaBinding{} = Just (Alpha (AlphaIndex "λ"))
+bindingAttr MetaBindings{} = Nothing
+bindingAttr MetaDeltaBinding{} = Nothing
+
+zipBindings :: [Binding] -> [Binding] -> ([Binding], [(Binding, Binding)])
+zipBindings xs ys = (xs' <> ys', collisions)
+ where
+  as = map bindingAttr xs
+  bs = map bindingAttr ys
+
+  xs' = [x | x <- xs, bindingAttr x `notElem` bs]
+  ys' = [y | y <- ys, bindingAttr y `notElem` as]
+  collisions =
+    [ (x, y)
+    | x <- xs
+    , y <- ys
+    , bindingAttr x == bindingAttr y
+    ]
+
+isPackage :: [Binding] -> Bool
+isPackage = any isPackageBinding
+
+isPackageBinding :: Binding -> Bool
+isPackageBinding (LambdaBinding (Function "Package")) = True
+isPackageBinding _ = False
+
+mergeBinding :: Binding -> Binding -> Either String Binding
+mergeBinding (AlphaBinding a (Formation xs)) (AlphaBinding b (Formation ys))
+  | a == b =
+      trace ("Merging under " <> printTree a) $ AlphaBinding a . Formation <$> mergeBindings xs ys
+mergeBinding x y | x == y = return x
+mergeBinding x y =
+  Left $
+    concat @[]
+      [ "conflict when adding dependencies (trying to merge non-formations)"
+      , printTree x
+      , printTree y
+      ]
+
+mergeBindings :: [Binding] -> [Binding] -> Either String [Binding]
+mergeBindings xs ys
+  | isPackage xs && isPackage ys = do
+      case zipBindings xs ys of
+        (zs, collisions) -> do
+          ws <- mapM (uncurry mergeBinding) collisions
+          return (zs <> ws)
+  | otherwise =
+      Left $
+        concat @[]
+          [ "conflict when adding dependencies (trying to merge non-Package formations "
+          , printTree (Formation xs)
+          , printTree (Formation ys)
+          , " )"
+          ]
+
+deepMerge :: Program -> Program -> Either String Program
+deepMerge (Program xs) (Program ys) = Program <$> mergeBindings xs ys
+
+deepMergePrograms :: [Program] -> Either String Program
+deepMergePrograms [] = Right (Program [])
+deepMergePrograms (p : ps) = foldM deepMerge p ps
+
+-- * Main
+
 main :: IO ()
 main = do
   opts <- customExecParser pprefs cliOpts
@@ -348,9 +431,13 @@ main = do
       logStrLn $ encodeToJSONString metrics
     CLI'TransformPhi' CLI'TransformPhi{..} -> do
       program' <- getProgram inputFile
+      deps <- mapM (getProgram . Just) dependencies
       (logStrLn, logStr) <- getLoggers outputFile
       ruleSet <- parseRuleSetFromFile rulesPath
       unless (single || json) $ logStrLn ruleSet.title
+      bindingsWithDeps <- case deepMergePrograms (program' : deps) of
+        Left err -> throw (CouldNotMergeDependencies err)
+        Right (Program bindingsWithDeps) -> return bindingsWithDeps
       let Program bindings = program'
           uniqueResults
             -- Something here seems incorrect
@@ -358,7 +445,7 @@ main = do
             | otherwise = pure . ("",) <$> applyRulesWith limits ctx (Formation bindings)
            where
             limits = ApplicationLimits maxDepth (maxGrowthFactor * objectSize (Formation bindings))
-            ctx = defaultContext (convertRuleNamed <$> ruleSet.rules) (Formation bindings)
+            ctx = defaultContext (convertRuleNamed <$> ruleSet.rules) (Formation bindingsWithDeps) -- IMPORTANT: context contains dependencies!
           totalResults = length uniqueResults
       when (null uniqueResults || null (head uniqueResults)) (throw CouldNotNormalize)
       if
@@ -393,10 +480,14 @@ main = do
     CLI'DataizePhi' CLI'DataizePhi{..} -> do
       (logStrLn, _logStr) <- getLoggers outputFile
       program' <- getProgram inputFile
+      deps <- mapM (getProgram . Just) dependencies
+      bindingsWithDeps <- case deepMergePrograms (program' : deps) of
+        Left err -> throw (CouldNotMergeDependencies err)
+        Right (Program bindingsWithDeps) -> return bindingsWithDeps
       ruleSet <- parseRuleSetFromFile rulesPath
       let (Program bindings) = program'
       let inputObject = Formation bindings
-      let ctx = defaultContext (convertRuleNamed <$> ruleSet.rules) inputObject
+      let ctx = defaultContext (convertRuleNamed <$> ruleSet.rules) (Formation bindingsWithDeps) -- IMPORTANT: context contains dependencies!
       ( if chain
           then do
             let dataizeChain

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
@@ -17,6 +16,7 @@ import Data.List (nubBy, sortOn)
 import Data.List.NonEmpty (NonEmpty (..), (<|))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.String (IsString (..))
+import Debug.Trace (trace)
 import Language.EO.Phi.Syntax.Abs
 import Language.EO.Phi.Syntax.Lex (Token)
 import Language.EO.Phi.Syntax.Par
@@ -56,6 +56,8 @@ data Context = Context
   , currentAttr :: Attribute
   , insideFormation :: Bool
   -- ^ Temporary hack for applying Ksi and Phi rules when dataizing
+  , dataizePackage :: Bool
+  -- ^ Temporary flag to only dataize Package attributes for the top-level formation.
   }
 
 sameContext :: Context -> Context -> Bool
@@ -72,6 +74,7 @@ defaultContext rules obj =
     , outerFormations = NonEmpty.singleton obj
     , currentAttr = Sigma
     , insideFormation = False
+    , dataizePackage = True
     }
 
 -- | A rule tries to apply a transformation to the root object, if possible.
@@ -253,7 +256,7 @@ instance Monad (Chain a) where
     ]
 
 logStep :: String -> info -> Chain info ()
-logStep msg info = Chain $ const [([(msg, info)], ())]
+logStep msg info = trace msg $ Chain $ const [([(msg, info)], ())]
 
 choose :: [a] -> Chain log a
 choose xs = Chain $ \_ctx -> [(mempty, x) | x <- xs]
@@ -274,7 +277,10 @@ getContext :: Chain a Context
 getContext = Chain $ \ctx -> [([], ctx)]
 
 withContext :: Context -> Chain log a -> Chain log a
-withContext ctx (Chain f) = Chain (\_ -> f ctx)
+withContext = modifyContext . const
+
+modifyContext :: (Context -> Context) -> Chain log a -> Chain log a
+modifyContext g (Chain f) = Chain (f . g)
 
 applyRulesChain' :: Context -> Object -> [([(String, Object)], Object)]
 applyRulesChain' ctx obj = applyRulesChainWith' (defaultApplicationLimits (objectSize obj)) ctx obj

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -16,7 +16,6 @@ import Data.List (nubBy, sortOn)
 import Data.List.NonEmpty (NonEmpty (..), (<|))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.String (IsString (..))
-import Debug.Trace (trace)
 import Language.EO.Phi.Syntax.Abs
 import Language.EO.Phi.Syntax.Lex (Token)
 import Language.EO.Phi.Syntax.Par
@@ -256,7 +255,7 @@ instance Monad (Chain a) where
     ]
 
 logStep :: String -> info -> Chain info ()
-logStep msg info = trace msg $ Chain $ const [([(msg, info)], ())]
+logStep msg info = Chain $ const [([(msg, info)], ())]
 
 choose :: [a] -> Chain log a
 choose xs = Chain $ \_ctx -> [(mempty, x) | x <- xs]

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/as-phi.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/as-phi.phi
@@ -1,0 +1,14 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        as-phi ↦ ⟦
+          λ ⤍ Lambda,
+          x ↦ ∅
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/bool.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/bool.phi
@@ -1,0 +1,82 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        bool ↦ ⟦
+          as-bytes ↦ ∅,
+          φ ↦ ξ.as-bytes,
+          eq ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.as-bytes.eq(
+              α0 ↦ ξ.x.as-bytes
+            )
+          ⟧,
+          if ↦ ⟦
+            λ ⤍ Lambda,
+            t ↦ ∅,
+            f ↦ ∅
+          ⟧,
+          not ↦ ⟦
+            φ ↦ ξ.ρ.eq(
+              α0 ↦ ξ.σ.σ.bool(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-
+                )
+              )
+            )
+          ⟧,
+          and ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.if(
+              α0 ↦ ξ.x.if(
+                α0 ↦ ξ.σ.σ.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 01-
+                  )
+                ),
+                α1 ↦ ξ.σ.σ.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-
+                  )
+                )
+              ),
+              α1 ↦ ξ.σ.σ.bool(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-
+                )
+              )
+            )
+          ⟧,
+          or ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.if(
+              α0 ↦ ξ.σ.σ.bool(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 01-
+                )
+              ),
+              α1 ↦ ξ.x.if(
+                α0 ↦ ξ.σ.σ.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 01-
+                  )
+                ),
+                α1 ↦ ξ.σ.σ.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-
+                  )
+                )
+              )
+            )
+          ⟧,
+          while ↦ ⟦
+            λ ⤍ Lambda,
+            f ↦ ∅
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/bytes.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/bytes.phi
@@ -3,6 +3,7 @@
     org ↦ ⟦
       eolang ↦ ⟦
         bytes ↦ ⟦
+          Δ ⤍ ∅,
           eq ↦ ⟦
             λ ⤍ Lambda,
             x ↦ ∅

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/bytes.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/bytes.phi
@@ -1,0 +1,72 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        bytes ↦ ⟦
+          eq ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          size ↦ ⟦
+            λ ⤍ Lambda
+          ⟧,
+          slice ↦ ⟦
+            λ ⤍ Lambda,
+            start ↦ ∅,
+            len ↦ ∅
+          ⟧,
+          as-string ↦ ⟦
+            λ ⤍ Lambda
+          ⟧,
+          as-int ↦ ⟦
+            λ ⤍ Lambda
+          ⟧,
+          as-float ↦ ⟦
+            λ ⤍ Lambda
+          ⟧,
+          and ↦ ⟦
+            λ ⤍ Lambda,
+            b ↦ ∅
+          ⟧,
+          or ↦ ⟦
+            λ ⤍ Lambda,
+            b ↦ ∅
+          ⟧,
+          xor ↦ ⟦
+            λ ⤍ Lambda,
+            b ↦ ∅
+          ⟧,
+          not ↦ ⟦
+            λ ⤍ Lambda
+          ⟧,
+          left ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.right(
+              α0 ↦ ξ.x.neg
+            )
+          ⟧,
+          right ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          as-bool ↦ ⟦
+            φ ↦ ξ.ρ.eq(
+              α0 ↦ ξ.σ.σ.bytes(
+                Δ ⤍ 01-
+              )
+            )
+          ⟧,
+          as-bytes ↦ ⟦
+            φ ↦ ξ.ρ
+          ⟧,
+          concat ↦ ⟦
+            λ ⤍ Lambda,
+            b ↦ ∅
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/cage.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/cage.phi
@@ -1,0 +1,13 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        cage ↦ ⟦
+          λ ⤍ Lambda
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/cti.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/cti.phi
@@ -1,0 +1,16 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        cti ↦ ⟦
+          delegate ↦ ∅,
+          level ↦ ∅,
+          message ↦ ∅,
+          φ ↦ ξ.delegate
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/error.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/error.phi
@@ -1,0 +1,13 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        error ↦ ⟦
+          λ ⤍ Lambda
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/float.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/float.phi
@@ -1,0 +1,127 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        float ↦ ⟦
+          as-bytes ↦ ∅,
+          φ ↦ ξ.as-bytes,
+          eq ↦ ⟦
+            x ↦ ∅,
+            x-as-bytes ↦ ξ.x.as-bytes,
+            self-as-bytes ↦ ξ.ρ.as-bytes,
+            nan-as-bytes ↦ Φ.org.eolang.nan.as-bytes,
+            pos-zero-as-bytes ↦ ξ.σ.σ.float(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-00-00-00-00-00-00-00
+              )
+            ).as-bytes,
+            neg-zero-as-bytes ↦ ξ.σ.σ.float(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 80-00-00-00-00-00-00-00
+              )
+            ).as-bytes,
+            φ ↦ ξ.x-as-bytes.eq(
+              α0 ↦ ξ.nan-as-bytes
+            ).or(
+              α0 ↦ ξ.self-as-bytes.eq(
+                α0 ↦ ξ.nan-as-bytes
+              )
+            ).if(
+              α0 ↦ Φ.org.eolang.bool(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-
+                )
+              ),
+              α1 ↦ ξ.x-as-bytes.eq(
+                α0 ↦ ξ.pos-zero-as-bytes
+              ).or(
+                α0 ↦ ξ.x-as-bytes.eq(
+                  α0 ↦ ξ.neg-zero-as-bytes
+                )
+              ).and(
+                α0 ↦ ξ.self-as-bytes.eq(
+                  α0 ↦ ξ.pos-zero-as-bytes
+                ).or(
+                  α0 ↦ ξ.self-as-bytes.eq(
+                    α0 ↦ ξ.neg-zero-as-bytes
+                  )
+                )
+              ).or(
+                α0 ↦ ξ.self-as-bytes.eq(
+                  α0 ↦ ξ.x-as-bytes
+                )
+              )
+            )
+          ⟧,
+          lt ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.neg.plus(
+              α0 ↦ ξ.x
+            ).gt(
+              α0 ↦ ξ.σ.σ.float(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-00-00-00-00-00-00-00
+                )
+              )
+            )
+          ⟧,
+          lte ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            φ ↦ ξ.ρ.eq(
+              α0 ↦ ξ.value
+            ).or(
+              α0 ↦ ξ.ρ.lt(
+                α0 ↦ ξ.value
+              )
+            )
+          ⟧,
+          gt ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          gte ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            φ ↦ ξ.ρ.eq(
+              α0 ↦ ξ.value
+            ).or(
+              α0 ↦ ξ.ρ.gt(
+                α0 ↦ ξ.value
+              )
+            )
+          ⟧,
+          times ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          plus ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          neg ↦ ⟦
+            φ ↦ ξ.ρ.times(
+              α0 ↦ ξ.σ.σ.float(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ BF-F0-00-00-00-00-00-00
+                )
+              )
+            )
+          ⟧,
+          minus ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.plus(
+              α0 ↦ ξ.x.neg
+            )
+          ⟧,
+          div ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/goto.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/goto.phi
@@ -1,0 +1,14 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        goto ↦ ⟦
+          λ ⤍ Lambda,
+          f ↦ ∅
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/heap.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/heap.phi
@@ -1,0 +1,103 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        heap ↦ ⟦
+          size ↦ ∅,
+          malloc ↦ ⟦
+            s ↦ ∅,
+            next ↦ Φ.org.eolang.memory(
+              α0 ↦ Φ.org.eolang.int(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-00-00-00-00-00-00-00
+                )
+              )
+            ),
+            new-next ↦ ξ.s.plus(
+              α0 ↦ ξ.ρ.malloc.next.as-int
+            ),
+            φ ↦ ξ.new-next.gt(
+              α0 ↦ ξ.σ.size
+            ).if(
+              α0 ↦ Φ.org.eolang.error(
+                α0 ↦ Φ.org.eolang.string(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 41-6C-6C-6F-63-61-74-69-6F-6E-20-66-61-69-6C-65-64-3A-20-62-61-64-20-61-6C-6C-6F-63-20-28-6E-6F-74-20-65-6E-6F-75-67-68-20-6D-65-6D-6F-72-79-20-69-6E-20-74-68-65-20-68-65-61-70-29
+                  )
+                )
+              ),
+              α1 ↦ Φ.org.eolang.seq(
+                α0 ↦ Φ.org.eolang.tuple(
+                  α0 ↦ Φ.org.eolang.tuple(
+                    α0 ↦ Φ.org.eolang.tuple.empty,
+                    α1 ↦ ξ.ρ.malloc.next.write(
+                      α0 ↦ ξ.new-next
+                    )
+                  ),
+                  α1 ↦ Φ.org.eolang.int(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 00-00-00-00-00-00-00-00
+                    )
+                  ).plus(
+                    α0 ↦ ξ.ρ.malloc.next.as-int
+                  )
+                )
+              )
+            )
+          ⟧,
+          free ↦ ⟦
+            p ↦ ∅,
+            φ ↦ Φ.org.eolang.seq(
+              α0 ↦ Φ.org.eolang.tuple(
+                α0 ↦ Φ.org.eolang.tuple(
+                  α0 ↦ Φ.org.eolang.tuple.empty,
+                  α1 ↦ ξ.p
+                ),
+                α1 ↦ Φ.org.eolang.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 01-
+                  )
+                )
+              )
+            )
+          ⟧,
+          pointer ↦ ⟦
+            address ↦ ∅,
+            length ↦ ∅,
+            φ ↦ ξ.address,
+            add ↦ ⟦
+              x ↦ ∅,
+              φ ↦ ξ.σ.ρ.pointer(
+                α0 ↦ ξ.σ.address.plus(
+                  α0 ↦ ξ.σ.length.times(
+                    α0 ↦ ξ.x
+                  )
+                ),
+                α1 ↦ ξ.σ.length
+              )
+            ⟧,
+            sub ↦ ⟦
+              x ↦ ∅,
+              φ ↦ ξ.σ.add(
+                α0 ↦ ξ.x.times(
+                  α0 ↦ Φ.org.eolang.int(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ FF-FF-FF-FF-FF-FF-FF-FF
+                    )
+                  )
+                )
+              )
+            ⟧,
+            block ↦ ⟦
+              λ ⤍ Lambda,
+              len ↦ ∅,
+              inverse ↦ ∅
+            ⟧
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/int.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/int.phi
@@ -1,0 +1,75 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        int ↦ ⟦
+          as-bytes ↦ ∅,
+          φ ↦ ξ.as-bytes,
+          eq ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.as-bytes.eq(
+              α0 ↦ ξ.x.as-bytes
+            )
+          ⟧,
+          lt ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.x.plus(
+              α0 ↦ ξ.ρ.neg
+            ).gt(
+              α0 ↦ ξ.σ.σ.int(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-00-00-00-00-00-00-00
+                )
+              )
+            )
+          ⟧,
+          lte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.gt(
+              α0 ↦ ξ.x
+            ).not
+          ⟧,
+          gt ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          gte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.lt(
+              α0 ↦ ξ.x
+            ).not
+          ⟧,
+          neg ↦ ⟦
+            φ ↦ ξ.ρ.times(
+              α0 ↦ ξ.σ.σ.int(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ FF-FF-FF-FF-FF-FF-FF-FF
+                )
+              )
+            )
+          ⟧,
+          plus ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          minus ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.plus(
+              α0 ↦ ξ.x.neg
+            )
+          ⟧,
+          times ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧,
+          div ↦ ⟦
+            λ ⤍ Lambda,
+            x ↦ ∅
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/io/stdin.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/io/stdin.phi
@@ -1,0 +1,21 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        io ↦ ⟦
+          stdin ↦ ⟦
+            next-line ↦ ⟦
+              λ ⤍ Lambda
+            ⟧,
+            φ ↦ ⟦
+              λ ⤍ Lambda
+            ⟧
+          ⟧,
+          λ ⤍ Package
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/io/stdout.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/io/stdout.phi
@@ -1,0 +1,17 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        io ↦ ⟦
+          stdout ↦ ⟦
+            λ ⤍ Lambda,
+            text ↦ ∅
+          ⟧,
+          λ ⤍ Package
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/memory.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/memory.phi
@@ -1,0 +1,13 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        memory ↦ ⟦
+          λ ⤍ Lambda
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/nan.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/nan.phi
@@ -1,0 +1,82 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        nan ↦ ⟦
+          φ ↦ Φ.org.eolang.float(
+            α0 ↦ Φ.org.eolang.bytes(
+              Δ ⤍ 00-00-00-00-00-00-00-00
+            )
+          ).div(
+            α0 ↦ Φ.org.eolang.float(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-00-00-00-00-00-00-00
+              )
+            )
+          ),
+          eq ↦ ⟦
+            x ↦ ∅,
+            φ ↦ Φ.org.eolang.bool(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-
+              )
+            )
+          ⟧,
+          lt ↦ ⟦
+            x ↦ ∅,
+            φ ↦ Φ.org.eolang.bool(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-
+              )
+            )
+          ⟧,
+          lte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ Φ.org.eolang.bool(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-
+              )
+            )
+          ⟧,
+          gt ↦ ⟦
+            x ↦ ∅,
+            φ ↦ Φ.org.eolang.bool(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-
+              )
+            )
+          ⟧,
+          gte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ Φ.org.eolang.bool(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-
+              )
+            )
+          ⟧,
+          times ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ
+          ⟧,
+          plus ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ
+          ⟧,
+          neg ↦ ⟦
+            φ ↦ ξ.ρ
+          ⟧,
+          minus ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ
+          ⟧,
+          div ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/negative-infinity.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/negative-infinity.phi
@@ -1,0 +1,246 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        negative-infinity ↦ ⟦
+          φ ↦ Φ.org.eolang.float(
+            α0 ↦ Φ.org.eolang.bytes(
+              Δ ⤍ BF-F0-00-00-00-00-00-00
+            )
+          ).div(
+            α0 ↦ Φ.org.eolang.float(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-00-00-00-00-00-00-00
+              )
+            )
+          ),
+          eq ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.as-bytes.eq(
+              α0 ↦ ξ.x.as-bytes
+            )
+          ⟧,
+          lt ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            φ ↦ ξ.value.as-bytes.eq(
+              α0 ↦ Φ.org.eolang.nan.as-bytes
+            ).or(
+              α0 ↦ ξ.ρ.eq(
+                α0 ↦ ξ.value
+              )
+            ).not
+          ⟧,
+          lte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.x.as-bytes.eq(
+              α0 ↦ Φ.org.eolang.nan.as-bytes
+            ).not
+          ⟧,
+          gt ↦ ⟦
+            x ↦ ∅,
+            φ ↦ Φ.org.eolang.bool(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-
+              )
+            )
+          ⟧,
+          gte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.eq(
+              α0 ↦ ξ.x
+            )
+          ⟧,
+          times ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            is-num-gt-zero ↦ ⟦
+              num ↦ ∅,
+              φ ↦ Φ.org.eolang.try(
+                α0 ↦ ⟦
+                  φ ↦ ξ.σ.num.gt(
+                    α0 ↦ Φ.org.eolang.int(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α1 ↦ ⟦
+                  e ↦ ∅,
+                  φ ↦ ξ.σ.num.gt(
+                    α0 ↦ Φ.org.eolang.float(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α2 ↦ Φ.org.eolang.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-
+                  )
+                )
+              )
+            ⟧,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            is-nan-or-zero ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.σ.is-nan(
+                α0 ↦ ξ.num
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.float(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 80-00-00-00-00-00-00-00
+                    )
+                  )
+                )
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.float(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 00-00-00-00-00-00-00-00
+                    )
+                  )
+                )
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.int(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 00-00-00-00-00-00-00-00
+                    )
+                  )
+                )
+              )
+            ⟧,
+            φ ↦ ξ.is-nan-or-zero(
+              α0 ↦ ξ.value
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.is-num-gt-zero(
+                α0 ↦ ξ.value
+              ).if(
+                α0 ↦ ξ.σ.σ.negative-infinity,
+                α1 ↦ Φ.org.eolang.positive-infinity
+              )
+            )
+          ⟧,
+          plus ↦ ⟦
+            x ↦ ∅,
+            pos-inf-as-bytes ↦ Φ.org.eolang.positive-infinity.as-bytes,
+            value ↦ ξ.x,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            φ ↦ ξ.is-nan(
+              α0 ↦ ξ.value
+            ).or(
+              α0 ↦ ξ.value.as-bytes.eq(
+                α0 ↦ ξ.pos-inf-as-bytes
+              )
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.σ.σ.negative-infinity
+            )
+          ⟧,
+          minus ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            neg-inf-as-bytes ↦ ξ.σ.σ.negative-infinity.as-bytes,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            φ ↦ ξ.is-nan(
+              α0 ↦ ξ.value
+            ).or(
+              α0 ↦ ξ.value.as-bytes.eq(
+                α0 ↦ ξ.neg-inf-as-bytes
+              )
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.σ.σ.negative-infinity
+            )
+          ⟧,
+          div ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            is-nan-or-infinite ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.σ.is-nan(
+                α0 ↦ ξ.num
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.positive-infinity
+                )
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ ξ.σ.σ.σ.negative-infinity
+                )
+              )
+            ⟧,
+            is-num-gte-zero ↦ ⟦
+              num ↦ ∅,
+              φ ↦ Φ.org.eolang.try(
+                α0 ↦ ⟦
+                  φ ↦ ξ.σ.num.gte(
+                    α0 ↦ Φ.org.eolang.int(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α1 ↦ ⟦
+                  e ↦ ∅,
+                  φ ↦ ξ.σ.num.gte(
+                    α0 ↦ Φ.org.eolang.float(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α2 ↦ Φ.org.eolang.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-
+                  )
+                )
+              )
+            ⟧,
+            φ ↦ ξ.is-nan-or-infinite(
+              α0 ↦ ξ.value
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.is-num-gte-zero(
+                α0 ↦ ξ.value
+              ).if(
+                α0 ↦ ξ.σ.σ.negative-infinity,
+                α1 ↦ Φ.org.eolang.positive-infinity
+              )
+            )
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/nop.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/nop.phi
@@ -1,0 +1,18 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        nop ↦ ⟦
+          args ↦ ∅,
+          φ ↦ Φ.org.eolang.bool(
+            α0 ↦ Φ.org.eolang.bytes(
+              Δ ⤍ 01-
+            )
+          )
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/positive-infinity.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/positive-infinity.phi
@@ -1,0 +1,246 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        positive-infinity ↦ ⟦
+          φ ↦ Φ.org.eolang.float(
+            α0 ↦ Φ.org.eolang.bytes(
+              Δ ⤍ 3F-F0-00-00-00-00-00-00
+            )
+          ).div(
+            α0 ↦ Φ.org.eolang.float(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-00-00-00-00-00-00-00
+              )
+            )
+          ),
+          eq ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.as-bytes.eq(
+              α0 ↦ ξ.x.as-bytes
+            )
+          ⟧,
+          lt ↦ ⟦
+            x ↦ ∅,
+            φ ↦ Φ.org.eolang.bool(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-
+              )
+            )
+          ⟧,
+          lte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.eq(
+              α0 ↦ ξ.x
+            )
+          ⟧,
+          gt ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            φ ↦ ξ.value.as-bytes.eq(
+              α0 ↦ Φ.org.eolang.nan.as-bytes
+            ).or(
+              α0 ↦ ξ.ρ.eq(
+                α0 ↦ ξ.value
+              )
+            ).not
+          ⟧,
+          gte ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.x.as-bytes.eq(
+              α0 ↦ Φ.org.eolang.nan.as-bytes
+            ).not
+          ⟧,
+          times ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            is-nan-or-zero ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.σ.is-nan(
+                α0 ↦ ξ.num
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.float(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 80-00-00-00-00-00-00-00
+                    )
+                  )
+                )
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.float(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 00-00-00-00-00-00-00-00
+                    )
+                  )
+                )
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.int(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 00-00-00-00-00-00-00-00
+                    )
+                  )
+                )
+              )
+            ⟧,
+            is-num-gt-zero ↦ ⟦
+              num ↦ ∅,
+              φ ↦ Φ.org.eolang.try(
+                α0 ↦ ⟦
+                  φ ↦ ξ.σ.num.gt(
+                    α0 ↦ Φ.org.eolang.int(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α1 ↦ ⟦
+                  e ↦ ∅,
+                  φ ↦ ξ.σ.num.gt(
+                    α0 ↦ Φ.org.eolang.float(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α2 ↦ Φ.org.eolang.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-
+                  )
+                )
+              )
+            ⟧,
+            φ ↦ ξ.is-nan-or-zero(
+              α0 ↦ ξ.value
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.is-num-gt-zero(
+                α0 ↦ ξ.value
+              ).if(
+                α0 ↦ ξ.σ.σ.positive-infinity,
+                α1 ↦ Φ.org.eolang.negative-infinity
+              )
+            )
+          ⟧,
+          plus ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            neg-inf-as-bytes ↦ Φ.org.eolang.negative-infinity.as-bytes,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            φ ↦ ξ.is-nan(
+              α0 ↦ ξ.value
+            ).or(
+              α0 ↦ ξ.value.as-bytes.eq(
+                α0 ↦ ξ.neg-inf-as-bytes
+              )
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.σ.σ.positive-infinity
+            )
+          ⟧,
+          minus ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            pos-inf-as-bytes ↦ ξ.σ.σ.positive-infinity.as-bytes,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            φ ↦ ξ.is-nan(
+              α0 ↦ ξ.value
+            ).or(
+              α0 ↦ ξ.value.as-bytes.eq(
+                α0 ↦ ξ.pos-inf-as-bytes
+              )
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.σ.σ.positive-infinity
+            )
+          ⟧,
+          div ↦ ⟦
+            x ↦ ∅,
+            value ↦ ξ.x,
+            is-nan ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.num.eq(
+                α0 ↦ ξ.num
+              ).not
+            ⟧,
+            is-nan-or-infinite ↦ ⟦
+              num ↦ ∅,
+              φ ↦ ξ.σ.is-nan(
+                α0 ↦ ξ.num
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ ξ.σ.σ.σ.positive-infinity
+                )
+              ).or(
+                α0 ↦ ξ.num.eq(
+                  α0 ↦ Φ.org.eolang.negative-infinity
+                )
+              )
+            ⟧,
+            is-num-gte-zero ↦ ⟦
+              num ↦ ∅,
+              φ ↦ Φ.org.eolang.try(
+                α0 ↦ ⟦
+                  φ ↦ ξ.σ.num.gte(
+                    α0 ↦ Φ.org.eolang.int(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α1 ↦ ⟦
+                  e ↦ ∅,
+                  φ ↦ ξ.σ.num.gte(
+                    α0 ↦ Φ.org.eolang.float(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-00
+                      )
+                    )
+                  )
+                ⟧,
+                α2 ↦ Φ.org.eolang.bool(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-
+                  )
+                )
+              )
+            ⟧,
+            φ ↦ ξ.is-nan-or-infinite(
+              α0 ↦ ξ.value
+            ).if(
+              α0 ↦ Φ.org.eolang.nan,
+              α1 ↦ ξ.is-num-gte-zero(
+                α0 ↦ ξ.value
+              ).if(
+                α0 ↦ ξ.σ.σ.positive-infinity,
+                α1 ↦ Φ.org.eolang.negative-infinity
+              )
+            )
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/ram.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/ram.phi
@@ -1,0 +1,34 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        ram ↦ ⟦
+          size ↦ ∅,
+          write ↦ ⟦
+            λ ⤍ Lambda,
+            position ↦ ∅,
+            data ↦ ∅
+          ⟧,
+          slice ↦ ⟦
+            λ ⤍ Lambda,
+            position ↦ ∅,
+            size ↦ ∅
+          ⟧,
+          ram-slice ↦ ⟦
+            position ↦ ∅,
+            size ↦ ∅,
+            φ ↦ ⟦
+              λ ⤍ Lambda
+            ⟧,
+            write ↦ ⟦
+              λ ⤍ Lambda,
+              data ↦ ∅
+            ⟧
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/rust.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/rust.phi
@@ -1,0 +1,16 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        rust ↦ ⟦
+          λ ⤍ Lambda,
+          code ↦ ∅,
+          portal ↦ ∅,
+          params ↦ ∅
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/seq.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/seq.phi
@@ -1,0 +1,14 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        seq ↦ ⟦
+          λ ⤍ Lambda,
+          steps ↦ ∅
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/string.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/string.phi
@@ -1,0 +1,28 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        string ↦ ⟦
+          as-bytes ↦ ∅,
+          φ ↦ ξ.as-bytes,
+          eq ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.ρ.as-bytes.eq(
+              α0 ↦ ξ.x.as-bytes
+            )
+          ⟧,
+          length ↦ ⟦
+            λ ⤍ Lambda
+          ⟧,
+          slice ↦ ⟦
+            λ ⤍ Lambda,
+            start ↦ ∅,
+            len ↦ ∅
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/switch.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/switch.phi
@@ -1,0 +1,75 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        switch ↦ ⟦
+          cases ↦ ∅,
+          len ↦ ξ.cases.length,
+          case-at ↦ ⟦
+            index ↦ ∅,
+            φ ↦ ξ.index.eq(
+              α0 ↦ ξ.ρ.len
+            ).if(
+              α0 ↦ Φ.org.eolang.bool(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 01-
+                )
+              ),
+              α1 ↦ ξ.case.at(
+                α0 ↦ Φ.org.eolang.int(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 00-00-00-00-00-00-00-00
+                  )
+                )
+              ).if(
+                α0 ↦ ξ.case.at(
+                  α0 ↦ Φ.org.eolang.int(
+                    α0 ↦ Φ.org.eolang.bytes(
+                      Δ ⤍ 00-00-00-00-00-00-00-01
+                    )
+                  )
+                ),
+                α1 ↦ ξ.ρ.case-at(
+                  α0 ↦ ξ.index.plus(
+                    α0 ↦ Φ.org.eolang.int(
+                      α0 ↦ Φ.org.eolang.bytes(
+                        Δ ⤍ 00-00-00-00-00-00-00-01
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            case ↦ ξ.ρ.cases.at(
+              α0 ↦ ξ.index
+            )
+          ⟧,
+          φ ↦ ξ.cases.length.eq(
+            α0 ↦ Φ.org.eolang.int(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-00-00-00-00-00-00-00
+              )
+            )
+          ).if(
+            α0 ↦ Φ.org.eolang.error(
+              α0 ↦ Φ.org.eolang.string(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 73-77-69-74-63-68-20-63-61-73-65-73-20-61-72-65-20-65-6D-70-74-79
+                )
+              )
+            ),
+            α1 ↦ ξ.case-at(
+              α0 ↦ Φ.org.eolang.int(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-00-00-00-00-00-00-00
+                )
+              )
+            )
+          )
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/try.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/try.phi
@@ -1,0 +1,16 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        try ↦ ⟦
+          λ ⤍ Lambda,
+          main ↦ ∅,
+          catch ↦ ∅,
+          finally ↦ ∅
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/eo-phi-normalizer/test/eo/phi/org/eolang/tuple.phi
+++ b/eo-phi-normalizer/test/eo/phi/org/eolang/tuple.phi
@@ -1,0 +1,105 @@
+{
+  ⟦
+    org ↦ ⟦
+      eolang ↦ ⟦
+        tuple ↦ ⟦
+          head ↦ ∅,
+          tail ↦ ∅,
+          empty ↦ ⟦
+            at ↦ ⟦
+              i ↦ ∅,
+              φ ↦ Φ.org.eolang.error(
+                α0 ↦ Φ.org.eolang.string(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 43-61-6E-27-74-20-67-65-74-20-61-6E-20-6F-62-6A-65-63-74-20-66-72-6F-6D-20-74-68-65-20-65-6D-70-74-79-20-74-75-70-6C-65
+                  )
+                )
+              )
+            ⟧,
+            with ↦ ⟦
+              x ↦ ∅,
+              φ ↦ ξ.σ.σ.σ.tuple(
+                α0 ↦ ξ.σ.σ.σ.tuple.empty,
+                α1 ↦ ξ.x
+              )
+            ⟧,
+            length ↦ Φ.org.eolang.int(
+              α0 ↦ Φ.org.eolang.bytes(
+                Δ ⤍ 00-00-00-00-00-00-00-00
+              )
+            )
+          ⟧,
+          length ↦ ⟦
+            φ ↦ ξ.ρ.head.length.plus(
+              α0 ↦ Φ.org.eolang.int(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-00-00-00-00-00-00-01
+                )
+              )
+            )
+          ⟧,
+          at ↦ ⟦
+            i ↦ ∅,
+            idx ↦ ξ.i,
+            len ↦ ξ.ρ.length,
+            index ↦ ξ.idx.lt(
+              α0 ↦ Φ.org.eolang.int(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-00-00-00-00-00-00-00
+                )
+              )
+            ).if(
+              α0 ↦ ξ.len.plus(
+                α0 ↦ ξ.idx
+              ),
+              α1 ↦ ξ.idx
+            ),
+            φ ↦ ξ.index.lt(
+              α0 ↦ Φ.org.eolang.int(
+                α0 ↦ Φ.org.eolang.bytes(
+                  Δ ⤍ 00-00-00-00-00-00-00-00
+                )
+              )
+            ).or(
+              α0 ↦ ξ.index.gte(
+                α0 ↦ ξ.len
+              )
+            ).if(
+              α0 ↦ Φ.org.eolang.error(
+                α0 ↦ Φ.org.eolang.string(
+                  α0 ↦ Φ.org.eolang.bytes(
+                    Δ ⤍ 47-69-76-65-6E-20-69-6E-64-65-78-20-69-73-20-6F-75-74-20-6F-66-20-74-75-70-6C-65-20-62-6F-75-6E-64-73
+                  )
+                )
+              ),
+              α1 ↦ ξ.at-without-checks(
+                α0 ↦ ξ.index
+              )
+            ),
+            at-without-checks ↦ ⟦
+              i ↦ ∅,
+              idx ↦ ξ.i,
+              φ ↦ ξ.idx.lt(
+                α0 ↦ ξ.σ.σ.head.length
+              ).if(
+                α0 ↦ ξ.ρ.ρ.head.at.at-without-checks(
+                  α0 ↦ ξ.idx
+                ),
+                α1 ↦ ξ.ρ.ρ.tail
+              )
+            ⟧
+          ⟧,
+          with ↦ ⟦
+            x ↦ ∅,
+            φ ↦ ξ.σ.σ.tuple(
+              α0 ↦ ξ.ρ,
+              α1 ↦ ξ.x
+            )
+          ⟧
+        ⟧,
+        λ ⤍ Package
+      ⟧,
+      λ ⤍ Package
+    ⟧
+  ⟧
+}

--- a/site/docs/src/commands/normalizer-dataize.md
+++ b/site/docs/src/commands/normalizer-dataize.md
@@ -47,7 +47,7 @@ Available options:
   -h,--help                Show this help text
 ```
 
-### `--rules`
+### `--rules FILE`
 
 Similar to `--rules` for the `transform` subcommand, this argument accepts the path to a YAML file containing the rules to be used in the normalization phase.
 
@@ -70,9 +70,14 @@ Dataizing inside dispatch: ξ.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus (α0 ↦ �
 Nothing to dataize: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
 ```
 
-### `--output-file`
+### `--output-file FILE`
 
 Redirects the output to file of the given path instead of `stdout`.
+
+### `--dependency-file FILE`
+
+Injects package dependencies from a given file into the context when dataizing the input.
+Can be used multiple times to inject multiple dependencies.
 
 ### `--recursive`
 

--- a/site/docs/src/commands/normalizer-transform.md
+++ b/site/docs/src/commands/normalizer-transform.md
@@ -91,11 +91,12 @@ Available options:
   -h,--help                Show this help text
 ```
 
-### `--rules`
+### `--rules FILE`
 
-Normalize a 𝜑-expression from `program.phi` using the [yegor.yaml](#yegoryaml) rules.
+Normalize a 𝜑-expression from `program.phi` using the rules from a given file (e.g. [yegor.yaml](#yegoryaml)).
 
-There can be multiple numbered results that correspond to multiple rule application sequences.
+The output may contain multiple numbered results that correspond to different possible rule application sequences
+(even if the final result is the same).
 
 ```$ as console
 normalizer transform --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor.yaml program.phi
@@ -163,6 +164,15 @@ normalizer transform --single --json --rules ./eo-phi-normalizer/test/eo/phi/rul
 ```console
 "{ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ∅, d ↦ ⟦ φ ↦ ξ.ρ.c ⟧ ⟧, e ↦ ξ.b (c ↦ ⟦ ⟧).d ⟧ ⟧ }"
 ```
+
+### `--output-file FILE`
+
+Redirects the output to file of the given path instead of `stdout`.
+
+### `--dependency-file FILE`
+
+Injects package dependencies from a given file into the context when transforming the input.
+Can be used multiple times to inject multiple dependencies.
 
 ### `FILE` not specified (read from stdin)
 


### PR DESCRIPTION
Closes #242.

- [x] Support `--dependency-file` options
- [x] Add documentation
- [x] Add `org.eolang.*` dependencies as `.phi` files (generated by EO compiler, extracted from [the pipeline artifacts](https://github.com/objectionary/normalizer/actions/runs/8568395872#summary-23485202425) from `pipeline/phi/.eoc/phi/org/eolang` directory)
- [x] Figure out why dataization loops indefinitely if `bytes.phi` is not specified.
- [x] Figure out why dataization loops indefinitely when the actual `bool.phi` and `bytes.phi` are specified (ones generated by EO compiler).

The problem with non-termination was due to $\Phi.\mathsf{org}$ expanding into a package, which then was recursively dataized. Temporarily added a flag to avoid dataization of fields in `Package`s unless we are in a subformation of the program.

Also, `bytes.phi` generated by EO compiler lacks the empty delta binding, fixed that manually here.

### Example

```sh
stack run -- dataize --recursive --rules eo-phi-normalizer/test/eo/phi/rules/yegor.yaml --dependency-file bool.phi --dependency-file bytes.phi test.phi
```

```
{ ⟦ org ↦ ⟦ eolang ↦ ⟦ x ↦ ⟦ Δ ⤍ 01- ⟧, z ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧ }
```

Input files:

`bool.phi`:

```
{
  ⟦
    org ↦ ⟦
      eolang ↦ ⟦
        bool ↦ ⟦ α0 ↦ ∅, φ ↦ ξ.α0 ⟧,
        λ ⤍ Package
      ⟧,
      λ ⤍ Package
    ⟧,
    λ ⤍ Package
  ⟧
}
```

`bytes.phi`:

```
{
  ⟦
    org ↦ ⟦
      eolang ↦ ⟦
        bytes ↦ ⟦ Δ ⤍ ∅ ⟧,
        λ ⤍ Package
      ⟧,
      λ ⤍ Package
    ⟧,
    λ ⤍ Package
  ⟧
}
```

`test.phi`:

```
{
  ⟦
    org ↦ ⟦
      eolang ↦ ⟦
        x ↦ ⟦
          φ ↦ Φ.org.eolang.bool(
            α0 ↦ Φ.org.eolang.bytes(
              Δ ⤍ 01-
            )
          )
        ⟧,
        z ↦ ⟦
          y ↦ ⟦
            x ↦ ∅,
            φ ↦ ξ.x
          ⟧,
          φ ↦ Φ.org.eolang.bool(
            α0 ↦ Φ.org.eolang.bytes(
              Δ ⤍ 01-
            )
          )
        ⟧,
        λ ⤍ Package
      ⟧,
      λ ⤍ Package
    ⟧,
    λ ⤍ Package
  ⟧
}
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new normalization rules and file injection options to the `eo-phi-normalizer` tool. 

### Detailed summary
- Added new normalization rules for various objects
- Introduced `--rules FILE` argument for specifying rule files
- Added `--output-file FILE` option for redirecting output
- Included `--dependency-file FILE` to inject package dependencies
- Modified the `Context` struct in `Common.hs` to include a flag for dataizing Package attributes

> The following files were skipped due to too many changes: `eo-phi-normalizer/test/eo/phi/org/eolang/tuple.phi`, `eo-phi-normalizer/test/eo/phi/org/eolang/heap.phi`, `eo-phi-normalizer/test/eo/phi/org/eolang/float.phi`, `eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs`, `eo-phi-normalizer/test/eo/phi/org/eolang/negative-infinity.phi`, `eo-phi-normalizer/test/eo/phi/org/eolang/positive-infinity.phi`, `eo-phi-normalizer/app/Main.hs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->