### PR TITLE
Attempt to fix normalization and dataization rules w.r.t. xi and rho

### DIFF
--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -58,7 +58,7 @@ library
       src
   default-extensions:
       ImportQualifiedPost
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -91,7 +91,7 @@ executable normalizer
       app
   default-extensions:
       ImportQualifiedPost
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -146,7 +146,7 @@ test-suite doctests
       src
   default-extensions:
       ImportQualifiedPost
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9
@@ -189,7 +189,7 @@ test-suite spec
       test
   default-extensions:
       ImportQualifiedPost
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-missing-export-lists -threaded -rtsopts -with-rtsopts=-N
   build-tools:
       alex >=3.2.4
     , happy >=1.19.9

--- a/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
+++ b/eo-phi-normalizer/grammar/EO/Phi/Syntax.cf
@@ -22,6 +22,7 @@ ObjectDispatch. Object ::= Object "." Attribute ;
 GlobalObject.   Object ::= "Φ";
 ThisObject.     Object ::= "ξ";
 Termination.    Object ::= "⊥" ;
+MetaSubstThis.  Object ::= Object "[" "ξ" "↦" Object "]" ;
 MetaObject.     Object ::= MetaId ;
 MetaFunction.   Object ::= MetaFunctionName "(" Object ")" ;
 

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -64,7 +64,6 @@ ghc-options:
   - -Widentities
   - -Wincomplete-record-updates
   - -Wincomplete-uni-patterns
-  - -Wmissing-export-lists
   - -Wmissing-home-modules
   - -Wpartial-fields
   - -Wredundant-constraints

--- a/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
@@ -9,19 +9,10 @@
 
 module Language.EO.Phi.Dataize where
 
-import Control.Arrow (ArrowChoice (left))
 import Data.List (singleton)
 import Data.Maybe (listToMaybe)
-import Language.EO.Phi (Binding (DeltaEmptyBinding, EmptyBinding))
 import Language.EO.Phi.Rules.Common
-import Language.EO.Phi.Syntax.Abs (
-  AlphaIndex (AlphaIndex),
-  Attribute (Alpha, Phi, Rho),
-  Binding (AlphaBinding, DeltaBinding, LambdaBinding),
-  Bytes (Bytes),
-  Function (Function),
-  Object (Application, Formation, ObjectDispatch, Termination),
- )
+import Language.EO.Phi.Syntax.Abs
 import PyF (fmt)
 
 -- | Perform one step of dataization to the object (if possible).

--- a/eo-phi-normalizer/src/Language/EO/Phi/Normalize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Normalize.hs
@@ -83,6 +83,7 @@ peelObject = \case
   Termination -> PeeledObject HeadTermination []
   MetaObject _ -> PeeledObject HeadTermination []
   MetaFunction _ _ -> error "To be honest, I'm not sure what should be here"
+  MetaSubstThis{} -> error "impossible"
  where
   followedBy (PeeledObject object actions) action = PeeledObject object (actions ++ [action])
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-missing-export-lists #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-missing-export-lists #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
@@ -94,12 +95,18 @@ extendContextWith obj ctx =
     { outerFormations = obj <| outerFormations ctx
     }
 
+isEmptyBinding :: Binding -> Bool
+isEmptyBinding EmptyBinding{} = True
+isEmptyBinding DeltaEmptyBinding{} = True
+isEmptyBinding _ = False
+
 withSubObject :: (Context -> Object -> [(String, Object)]) -> Context -> Object -> [(String, Object)]
 withSubObject f ctx root =
   f ctx root
     <|> case root of
-      Formation bindings ->
-        propagateName1 Formation <$> withSubObjectBindings f ((extendContextWith root ctx){insideFormation = True}) bindings
+      Formation bindings
+        | not (any isEmptyBinding bindings) -> propagateName1 Formation <$> withSubObjectBindings f ((extendContextWith root ctx){insideFormation = True}) bindings
+        | otherwise -> []
       Application obj bindings ->
         asum
           [ propagateName2 Application <$> withSubObject f ctx obj <*> pure bindings
@@ -111,6 +118,7 @@ withSubObject f ctx root =
       Termination -> []
       MetaObject _ -> []
       MetaFunction _ _ -> []
+      MetaSubstThis _ _ -> []
 
 -- | Given a unary function that operates only on plain objects,
 -- converts it to a function that operates on named objects
@@ -172,6 +180,7 @@ objectSize = \case
   Termination -> 1
   MetaObject{} -> 1 -- should be impossible
   MetaFunction{} -> 1 -- should be impossible
+  MetaSubstThis{} -> 1 -- should be impossible
 
 bindingSize :: Binding -> Int
 bindingSize = \case

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -29,7 +29,6 @@ import GHC.Generics (Generic)
 import Language.EO.Phi
 import Language.EO.Phi.Rules.Common (Context (insideFormation, outerFormations), NamedRule)
 import Language.EO.Phi.Rules.Common qualified as Common
-import Language.EO.Phi.Syntax.Abs
 import PyF (fmt)
 
 -- $setup

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs
@@ -255,12 +255,16 @@ substThis thisObj = go
  where
   isAttachedRho (AlphaBinding Rho _) = True
   isAttachedRho _ = False
+
+  isEmptyRho (EmptyBinding Rho) = True
+  isEmptyRho _ = False
+
   go = \case
     ThisObject -> thisObj -- ξ is substituted
     -- IMPORTANT: we are injecting a ρ-attribute in formations!
     obj@(Formation bindings)
       | any isAttachedRho bindings -> obj
-      | otherwise -> Formation (bindings ++ [AlphaBinding Rho thisObj])
+      | otherwise -> Formation (filter (not . isEmptyRho) bindings ++ [AlphaBinding Rho thisObj])
     -- everywhere else we simply recursively traverse the φ-term
     Application obj bindings -> Application (go obj) (map (substThisBinding thisObj) bindings)
     ObjectDispatch obj a -> ObjectDispatch (go obj) a

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Abs.hs
@@ -25,6 +25,7 @@ data Object
     | GlobalObject
     | ThisObject
     | Termination
+    | MetaSubstThis Object Object
     | MetaObject MetaId
     | MetaFunction MetaFunctionName Object
   deriving (C.Eq, C.Ord, C.Show, C.Read, C.Data, C.Typeable, C.Generic)

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Doc.txt
@@ -51,7 +51,8 @@ The reserved words used in Syntax are the following:
 The symbols used in Syntax are the following:
   | { | ⟦ | ⟧ | }
   | ( | ) | . | ⊥
-  | ↦ | ∅ | ⤍ | ,
+  | [ | ↦ | ] | ∅
+  | ⤍ | , |  |
 
 ===Comments===
 Single-line comments begin with //.Multiple-line comments are  enclosed with /* and */.
@@ -69,6 +70,7 @@ All other symbols are terminals.
   |  |  **|**  | ``Φ``
   |  |  **|**  | ``ξ``
   |  |  **|**  | ``⊥``
+  |  |  **|**  | //Object// ``[`` ``ξ`` ``↦`` //Object// ``]``
   |  |  **|**  | //MetaId//
   |  |  **|**  | //MetaFunctionName// ``(`` //Object// ``)``
   | //Binding// | -> | //Attribute// ``↦`` //Object//

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Lex.x
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Lex.x
@@ -28,7 +28,7 @@ $u = [. \n]          -- universal: any character
 
 -- Symbols and non-identifier-like reserved words
 
-@rsyms = \Φ | \ξ | \Δ | \λ | \φ | \ρ | \σ | \ν | \{ | \⟦ | \⟧ | \} | \( | \) | \. | \⊥ | \↦ | \∅ | \⤍ | \,
+@rsyms = \Φ | \ξ | \Δ | \λ | \φ | \ρ | \σ | \ν | \{ | \⟦ | \⟧ | \} | \( | \) | \. | \⊥ | \[ | \↦ | \] | \∅ | \⤍ | \,
 
 :-
 
@@ -186,14 +186,17 @@ eitherResIdent tv s = treeFind resWords
 -- | The keywords and symbols of the language organized as binary search tree.
 resWords :: BTree
 resWords =
-  b "\958" 11
-    (b "}" 6
-       (b "," 3 (b ")" 2 (b "(" 1 N N) N) (b "{" 5 (b "." 4 N N) N))
-       (b "\955" 9 (b "\934" 8 (b "\916" 7 N N) N) (b "\957" 10 N N)))
-    (b "\8709" 16
-       (b "\966" 14 (b "\963" 13 (b "\961" 12 N N) N) (b "\8614" 15 N N))
-       (b "\10215" 19
-          (b "\10214" 18 (b "\8869" 17 N N) N) (b "\10509" 20 N N)))
+  b "\957" 12
+    (b "]" 6
+       (b "," 3 (b ")" 2 (b "(" 1 N N) N) (b "[" 5 (b "." 4 N N) N))
+       (b "\916" 9
+          (b "}" 8 (b "{" 7 N N) N) (b "\955" 11 (b "\934" 10 N N) N)))
+    (b "\8709" 18
+       (b "\963" 15
+          (b "\961" 14 (b "\958" 13 N N) N)
+          (b "\8614" 17 (b "\966" 16 N N) N))
+       (b "\10215" 21
+          (b "\10214" 20 (b "\8869" 19 N N) N) (b "\10509" 22 N N)))
   where
   b s n = B bs (TS bs n)
     where

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y
@@ -45,22 +45,24 @@ import Language.EO.Phi.Syntax.Lex
   ')'                { PT _ (TS _ 2)                }
   ','                { PT _ (TS _ 3)                }
   '.'                { PT _ (TS _ 4)                }
-  '{'                { PT _ (TS _ 5)                }
-  '}'                { PT _ (TS _ 6)                }
-  'Δ'                { PT _ (TS _ 7)                }
-  'Φ'                { PT _ (TS _ 8)                }
-  'λ'                { PT _ (TS _ 9)                }
-  'ν'                { PT _ (TS _ 10)               }
-  'ξ'                { PT _ (TS _ 11)               }
-  'ρ'                { PT _ (TS _ 12)               }
-  'σ'                { PT _ (TS _ 13)               }
-  'φ'                { PT _ (TS _ 14)               }
-  '↦'                { PT _ (TS _ 15)               }
-  '∅'                { PT _ (TS _ 16)               }
-  '⊥'                { PT _ (TS _ 17)               }
-  '⟦'                { PT _ (TS _ 18)               }
-  '⟧'                { PT _ (TS _ 19)               }
-  '⤍'                { PT _ (TS _ 20)               }
+  '['                { PT _ (TS _ 5)                }
+  ']'                { PT _ (TS _ 6)                }
+  '{'                { PT _ (TS _ 7)                }
+  '}'                { PT _ (TS _ 8)                }
+  'Δ'                { PT _ (TS _ 9)                }
+  'Φ'                { PT _ (TS _ 10)               }
+  'λ'                { PT _ (TS _ 11)               }
+  'ν'                { PT _ (TS _ 12)               }
+  'ξ'                { PT _ (TS _ 13)               }
+  'ρ'                { PT _ (TS _ 14)               }
+  'σ'                { PT _ (TS _ 15)               }
+  'φ'                { PT _ (TS _ 16)               }
+  '↦'                { PT _ (TS _ 17)               }
+  '∅'                { PT _ (TS _ 18)               }
+  '⊥'                { PT _ (TS _ 19)               }
+  '⟦'                { PT _ (TS _ 20)               }
+  '⟧'                { PT _ (TS _ 21)               }
+  '⤍'                { PT _ (TS _ 22)               }
   L_Bytes            { PT _ (T_Bytes $$)            }
   L_Function         { PT _ (T_Function $$)         }
   L_LabelId          { PT _ (T_LabelId $$)          }
@@ -100,6 +102,7 @@ Object
   | 'Φ' { Language.EO.Phi.Syntax.Abs.GlobalObject }
   | 'ξ' { Language.EO.Phi.Syntax.Abs.ThisObject }
   | '⊥' { Language.EO.Phi.Syntax.Abs.Termination }
+  | Object '[' 'ξ' '↦' Object ']' { Language.EO.Phi.Syntax.Abs.MetaSubstThis $1 $5 }
   | MetaId { Language.EO.Phi.Syntax.Abs.MetaObject $1 }
   | MetaFunctionName '(' Object ')' { Language.EO.Phi.Syntax.Abs.MetaFunction $1 $3 }
 

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax/Print.hs
@@ -161,6 +161,7 @@ instance Print Language.EO.Phi.Syntax.Abs.Object where
     Language.EO.Phi.Syntax.Abs.GlobalObject -> prPrec i 0 (concatD [doc (showString "\934")])
     Language.EO.Phi.Syntax.Abs.ThisObject -> prPrec i 0 (concatD [doc (showString "\958")])
     Language.EO.Phi.Syntax.Abs.Termination -> prPrec i 0 (concatD [doc (showString "\8869")])
+    Language.EO.Phi.Syntax.Abs.MetaSubstThis object1 object2 -> prPrec i 0 (concatD [prt 0 object1, doc (showString "["), doc (showString "\958"), doc (showString "\8614"), prt 0 object2, doc (showString "]")])
     Language.EO.Phi.Syntax.Abs.MetaObject metaid -> prPrec i 0 (concatD [prt 0 metaid])
     Language.EO.Phi.Syntax.Abs.MetaFunction metafunctionname object -> prPrec i 0 (concatD [prt 0 metafunctionname, doc (showString "("), prt 0 object, doc (showString ")")])
 

--- a/eo-phi-normalizer/test/eo/phi/dataization.yaml
+++ b/eo-phi-normalizer/test/eo/phi/dataization.yaml
@@ -1,6 +1,6 @@
 title: Dataization tests
 tests:
-  - name: Celsius example
+  - name: "Celsius example"
     input: |
       {⟦
         σ ↦ Φ,
@@ -18,6 +18,140 @@ tests:
       ⟧}
     output:
       bytes: "52-"
+
+  - name: "Program with ξ.ρ.ρ"
+    input: |
+      {⟦ x ↦ ⟦ b ↦ ⟦ Δ ⤍ 01- ⟧, φ ↦ ⟦ b ↦ ⟦ Δ ⤍ 02- ⟧, c ↦ ⟦ a ↦ ξ.ρ.ρ.b, ρ ↦ ∅ ⟧.a, ρ ↦ ∅ ⟧.c, ρ ↦ ∅ ⟧.φ, λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ x ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
+
+  - name: "Preprocessing and dispatch"
+    input: |
+      {⟦ a ↦ ⟦ b ↦ ⟦ Δ ⤍ 01- ⟧ ⟧.b , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ a ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
+
+  - name: "New values in copy through ξ"
+    input: |
+      {⟦ a ↦ ⟦ b ↦ ∅, c ↦ ξ.b ⟧, d ↦ ξ.a(b ↦ ⟦ Δ ⤍ 01- ⟧).c , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ a ↦ ⟦ b ↦ ∅, c ↦ ξ.b ⟧, d ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
+
+  - name: "ρ-applications and stacked dispatches"
+    input: |
+      {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ ⟧ ⟧.a.b.c , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ x ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
+
+  - name: "ρ-applications and immediate dispatches"
+    input: |
+      {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ⟦ Δ ⤍ 01- ⟧ ⟧.c ⟧.b ⟧.a , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ x ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
+
+  - name: "new values in copy through ρ"
+    input: |
+      {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.c ⟧.b, c ↦ ∅ ⟧, d ↦ ξ.x(c ↦ ⟦ Δ ⤍ 01- ⟧).a , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.c ⟧.b, c ↦ ∅ ⟧, d ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
+
+  - name: "ρ and nested dispatches"
+    input: |
+      {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.c ⟧.b ⟧.a , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ x ↦ ⟦ ρ ↦ ⟦ ⟧ ⟧, λ ⤍ Package ⟧
+
+  - name: "usage of Φ with a loop"
+    input: |
+      {⟦ a ↦ ⟦ b ↦ Φ.a ⟧ , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ a ↦ ⟦ b ↦ Φ.a ⟧, λ ⤍ Package ⟧
+
+  - name: "ρ passed to both term of object application?"
+    input: |
+      {⟦ x ↦ ⟦ c ↦ ⟦ a ↦ ∅ ⟧ (a ↦ ⟦ d ↦ ξ.ρ ⟧) ⟧.c , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ x ↦ ⟦ a ↦ ⟦ d ↦ ξ.ρ ⟧, ρ ↦ ⟦ ⟧ ⟧, λ ⤍ Package ⟧
+
+  # FIXME: fails because nf condition for ξ.b succeeds though it shouldn't
+  # - name: "ξ in application"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ∅ ⟧(a ↦ ξ.b), b ↦ ⟦ Δ ⤍ 01- ⟧ , λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       {⟦ x ↦ ⟦ a ↦ ⟦ Δ ⤍ 01- ⟧ ⟧, b ↦ ⟦ Δ ⤍ 01- ⟧ , λ ⤍ Package ⟧}
+
+  - name: "ξ chain"
+    input: |
+      {⟦ a ↦ ξ.b, b ↦ ξ.c, c ↦ ξ.d, d ↦ ⟦ Δ ⤍ 01- ⟧ , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ a ↦ ⟦ Δ ⤍ 01- ⟧, b ↦ ⟦ Δ ⤍ 01- ⟧, c ↦ ⟦ Δ ⤍ 01- ⟧, d ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
+
+  # FIXME: fails
+  # - name: "cross-reference (1)"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.d.e, c ↦ ⟦ Δ ⤍ 01- ⟧, ρ ↦ ∅ ⟧, d ↦ ⟦ e ↦ ξ.ρ.a.c, ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧.a.b , λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       NOT ⟦ x ↦ ⊥, λ ⤍ Package ⟧
+
+  # FIXME: fails
+  # - name: "cross-reference (2)"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.d.e, c ↦ ξ.ρ.d.f ⟧, d ↦ ⟦ e ↦ ξ.ρ.a.c, f ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ ⟧.a.b , λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       NOT ⟦ x ↦ ⊥, λ ⤍ Package ⟧
+
+  # FIXME: fails
+  # - name: "cross-reference + dispatch (1)"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.d, c ↦ ⟦ Δ ⤍ 01- ⟧ ⟧, d ↦ ⟦ e ↦ ξ.ρ.a.c ⟧ ⟧.a.b.e , λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       NOT ⟦ x ↦ ⊥, λ ⤍ Package ⟧
+
+  # FIXME: fails
+  # - name: "cross-reference + dispatch (1)"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.d, c ↦ ⟦ Δ ⤍ 01- ⟧ ⟧, d ↦ ⟦ e ↦ ξ.ρ.a.c ⟧ ⟧.a.b.e , λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       NOT ⟦ x ↦ ⊥, λ ⤍ Package ⟧
+
+  # FIXME: fails
+  # - name: "cross-reference + dispatch (2)"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.d, c ↦ ξ.ρ.d.f ⟧, d ↦ ⟦ e ↦ ξ.ρ.a.c, f ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ ⟧.a.b.e , λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       NOT ⟦ x ↦ ⊥, λ ⤍ Package ⟧
+
+  # FIXME: fails
+  # - name: "cross-reference + dispatch (3)"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ξ.ρ.d, c ↦ ξ.ρ.d ⟧, d ↦ ⟦ e ↦ ξ.ρ.a.c, f ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ ⟧.a.b.e.f , λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       NOT ⟦ x ↦ ⊥, λ ⤍ Package ⟧
+
+  # FIXME: fails
+  # - name: "interleaving ρ and other dispatches"
+  #   input: |
+  #     {⟦ x ↦ ⟦ a ↦ ξ.ρ.b.ρ.c ⟧.a, b ↦ ⟦⟧, c ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧}
+  #   output:
+  #     object: |
+  #       NOT ⟦ x ↦ ⟦ ⟧.ρ.b.ρ.c, b ↦ ⟦ ⟧, c ↦ ⟦ Δ ⤍ 01- ⟧, λ ⤍ Package ⟧
 
   - name: "Dataize in siblings of Package"
     input: |

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -120,9 +120,24 @@ rules:
     pattern: |
       ⟦ !a ↦ !n, !B ⟧.!a
     result: |
-      !n(ρ ↦ ⟦ !B ⟧)
+      !n[ ξ ↦ ⟦ !B ⟧ ]
     when:
       - nf_inside_formation: '!n'
+    tests:
+      - name: Should match
+        input: ⟦ hello ↦ ⟦⟧ ⟧.hello
+        output: ['⟦⟧(ρ ↦ ⟦⟧)']
+      - name: Shouldn't match
+        input: ⟦ ⟧.hello
+        output: []
+
+  - name: Rule 6a
+    description: 'Accessing an α-binding (for object with ρ ↦ ∅)'
+    pattern: |
+      ⟦ !a ↦ !n, ρ ↦ ∅, !B ⟧.!a
+    result: |
+      !n[ ξ ↦ ⟦ !B ⟧ ]
+    when: []
     tests:
       - name: Should match
         input: ⟦ hello ↦ ⟦⟧ ⟧.hello

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -126,7 +126,7 @@ rules:
     tests:
       - name: Should match
         input: ⟦ hello ↦ ⟦⟧ ⟧.hello
-        output: ['⟦⟧(ρ ↦ ⟦⟧)']
+        output: ['⟦ ρ ↦ ⟦⟧ ⟧']
       - name: Shouldn't match
         input: ⟦ ⟧.hello
         output: []
@@ -140,8 +140,8 @@ rules:
     when: []
     tests:
       - name: Should match
-        input: ⟦ hello ↦ ⟦⟧ ⟧.hello
-        output: ['⟦⟧(ρ ↦ ⟦⟧)']
+        input: ⟦ hello ↦ ⟦⟧, ρ ↦ ∅ ⟧.hello
+        output: ['⟦ ρ ↦ ⟦⟧ ⟧']
       - name: Shouldn't match
         input: ⟦ ⟧.hello
         output: []

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -146,6 +146,19 @@ rules:
         input: ⟦ ⟧.hello
         output: []
 
+  - name: Rule 7 α0
+    description: 'Application of α-binding'
+    # Warning: this is not correct for the chain variant because it only matches the first binding
+    # i.e., doesn't match an empty binding after an attached one.
+    # We should instead match the first empty binding.
+    pattern: |
+      ⟦ !a ↦ ∅, !B ⟧(α0 ↦ !n)
+    result: |
+      ⟦ !a ↦ !n, !B ⟧
+    when:
+      - nf: '!n'
+    tests: []
+
   - name: Rule 7a
     description: 'Application of α-binding'
     pattern: |

--- a/site/docs/src/normalizer/dataize.md
+++ b/site/docs/src/normalizer/dataize.md
@@ -65,7 +65,6 @@ normalizer dataize --chain --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor.y
 
 ```console
 Dataizing inside phi: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
-Dataizing inside phi: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
 Dataizing inside application: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus
 Dataizing inside dispatch: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧)
 Dataizing inside application: ξ.c.times

--- a/site/docs/src/normalizer/dataize.md
+++ b/site/docs/src/normalizer/dataize.md
@@ -65,12 +65,8 @@ normalizer dataize --chain --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor.y
 
 ```console
 Dataizing inside phi: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
-Dataizing inside application: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus
-Dataizing inside dispatch: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧)
-Dataizing inside application: ξ.c.times
-Dataizing inside dispatch: ξ.c
-Dataizing inside dispatch: ξ
-Nothing to dataize: ξ
+Dataizing inside phi: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
+Nothing to dataize: ξ.c.times (α0 ↦ ⟦ Δ ⤍ 02- ⟧).plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
 ```
 
 ### `--output-file FILE`
@@ -91,7 +87,7 @@ normalizer dataize --recursive --rules eo-phi-normalizer/test/eo/phi/rules/yegor
 ```
 
 ```console
-52-
+⟦ α0 ↦ ⟦ Δ ⤍ 02- ⟧, λ ⤍ Times, ρ ↦ ⟦ Δ ⤍ 19-, plus ↦ ⟦ α0 ↦ ∅, λ ⤍ Plus ⟧, ρ ↦ ⟦ ρ ↦ ⟦ ⟧ ⟧ ⟧ ⟧.plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
 ```
 
 Can be combined with `--chain` to print all the intermediate steps of both normalization and dataization.
@@ -105,5 +101,5 @@ cat celsius.phi | normalizer dataize --recursive --rules ./eo-phi-normalizer/tes
 ```
 
 ```console
-52-
+⟦ α0 ↦ ⟦ Δ ⤍ 02- ⟧, λ ⤍ Times, ρ ↦ ⟦ Δ ⤍ 19-, plus ↦ ⟦ α0 ↦ ∅, λ ⤍ Plus ⟧, ρ ↦ ⟦ ρ ↦ ⟦ ⟧ ⟧ ⟧ ⟧.plus (α0 ↦ ⟦ Δ ⤍ 20- ⟧)
 ```

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,3 +2,6 @@ resolver: lts-22.16
 packages:
 - eo-phi-normalizer
 - scripts/transform-eo-tests
+extra-deps:
+- file-embed-0.0.16.0
+notify-if-nix-on-path: false

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: file-embed-0.0.16.0@sha256:2e8983240c1faae020b4acef6d30f0281f5ec87c2f38736dc1dc5456355e22a5,1426
+    pantry-tree:
+      sha256: db5accce9e81e002bf05f839b5f410728b3761dce6e9ccc6cc6648fa0b8cdaff
+      size: 478
+  original:
+    hackage: file-embed-0.0.16.0
 snapshots:
 - completed:
     sha256: 0cd905bf3f615a7f52d52fb6aadda182f695bd1cab10ef892095d974676f0911


### PR DESCRIPTION
Close #294.

- [x] Add `!object [ ξ ↦ !this ]` syntax for substitution of `ξ` (needed for the dispatch rule, treated as a builtin (meta)function).
- [x] `ξ`-substitution also performs `ρ`-injection in all immediate formations in `!object`
- [x] Normalization does not proceed inside formations with void attributes (baked into normalizer).
- [x] Dataization is fixed:

    - [x] Added comments explaining the importance of dataization inside dispatch and application
    - [x] context for `Package` atom is fixed, so dataization of package components has proper context
    
- [x] Update the rule for dispatch to use `ξ`-substitution (with `ρ`-injection) instead of application of `ρ`.
    
- [x] Silent some unimportant warnings.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `MetaSubstThis` object in the `Abs.hs` file, adds an error handling case, and updates various configuration files.

### Detailed summary
- Added `MetaSubstThis` object
- Updated error handling in `Normalize.hs`
- Modified configuration files in `stack.yaml`, `eo-phi-normalizer.cabal`, and `Par.y`

> The following files were skipped due to too many changes: `eo-phi-normalizer/src/Language/EO/Phi/Syntax/Par.y`, `eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs`, `eo-phi-normalizer/src/Language/EO/Phi/Rules/Yaml.hs`, `eo-phi-normalizer/test/eo/phi/dataization.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->