### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -142,7 +142,7 @@ jobs:
 
           if [ -n "$(git status --porcelain $files)" ]; then
             git add $files
-            git commit -m "Update Markdowfilesn files"
+            git commit -m "Update Markdown files"
             git push
           else
             printf "Nothing to commit."

--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -127,8 +127,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3.1.0
         with:
           crate: mdsh
-          # TODO #286:20m Use zimbatm/mdsh after https://github.com/zimbatm/mdsh/pull/63 is merged
-          git: https://github.com/deemp/mdsh
+          git: https://github.com/zimbatm/mdsh
           branch: main
 
       - name: Update Markdown files


### PR DESCRIPTION
- closes #298
- closes #295
<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the GitHub Actions workflow to use the `zimbatm/mdsh` crate instead of `deemp/mdsh`.

### Detailed summary
- Updated the `git` URL in the GitHub Actions workflow to point to `zimbatm/mdsh`
- Corrected a typo in the commit message from "Update Markdowfilesn files" to "Update Markdown files"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->