### PR TITLE
300 fix site directories

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -233,7 +233,7 @@ jobs:
         run: |
           cd site/docs
           mdbook build
-          mv docs ../../dist
+          mv docs/html ../../dist/docs
 
       - name: Add report
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -256,6 +256,7 @@
                 pkgs.gh
                 pkgs.mdsh
                 pkgs.mdbook
+                pkgs.mdbook-linkcheck
                 pkgs.yq-go
                 pkgs.jdk21
                 {

--- a/flake.nix
+++ b/flake.nix
@@ -146,6 +146,7 @@
 
           packages = mkShellApps {
             default = self'.packages.eo-phi-normalizer;
+
             pipeline = {
               runtimeInputs = [
                 stack-wrapped
@@ -159,6 +160,32 @@
               '';
               meta.description = "Run pipeline";
               excludeShellChecks = [ "SC2317" ];
+            };
+
+            site-dev = {
+              meta.description = "Run `mdbook serve` in `site/docs`";
+              runtimeInputs = [
+                pkgs.mdbook
+                pkgs.mdbook-linkcheck
+              ];
+              text = ''
+                cd site/docs
+                mdbook serve
+              '';
+            };
+
+            site-build = {
+              meta.description = "Run `mdbook build` in `site/docs` and move result to `dist/docs`";
+              runtimeInputs = [
+                pkgs.mdbook
+                pkgs.mdbook-linkcheck
+              ];
+              text = ''
+                cd site/docs
+                mdbook build
+                mkdir -p ../../dist/docs
+                mv docs/html ../../dist/docs
+              '';
             };
 
             update-markdown = {
@@ -247,7 +274,7 @@
                 {
                   prefix = "nix run .#";
                   packages = {
-                    inherit (self'.packages) pipeline update-markdown;
+                    inherit (self'.packages) pipeline update-markdown site-dev site-build;
                     normalizer = self'.packages.default;
                   };
                 }


### PR DESCRIPTION
Closes #300

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the GitHub Actions workflow by adding new scripts for serving and building documentation using `mdbook` and moving the results to `dist/docs`.

### Detailed summary
- Added `site-dev` and `site-build` scripts for `mdbook` operations
- Included `pkgs.mdbook-linkcheck` as a runtime input
- Updated the `packages` object to include new scripts and dependencies

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->