### PR TITLE
Remove special case for delta binding since VTX is removed

### DIFF
--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -250,9 +250,6 @@ equalBindings bindings1 bindings2 = and (zipWith equalBinding (sortOn attr bindi
 
 equalBinding :: Binding -> Binding -> Bool
 equalBinding (AlphaBinding attr1 obj1) (AlphaBinding attr2 obj2) = attr1 == attr2 && equalObject obj1 obj2
--- Ignore deltas for now while comparing since different normalization paths can lead to different vertex data
--- TODO #120:30m normalize the deltas instead of ignoring since this actually suppresses problems
-equalBinding (DeltaBinding _) (DeltaBinding _) = True
 equalBinding b1 b2 = b1 == b2
 
 -- * Chain variants


### PR DESCRIPTION
Fixes #176

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the `equalBinding` function in `Common.hs`.

### Detailed summary
- Improved comparison logic for `AlphaBinding` objects
- Removed ignoring of `DeltaBinding` objects for now

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->