### PR TITLE
fix(site): LTS version

### DIFF
--- a/site/docs/src/installation.md
+++ b/site/docs/src/installation.md
@@ -14,7 +14,7 @@ Then, the `normalizer` executable will be available on `PATH`.
 ```sh
 stack update
 export LC_ALL=C.UTF-8
-stack install --resolver lts-22.6 eo-phi-normalizer
+stack install --resolver lts-22.16 eo-phi-normalizer
 ```
 
 ## Update


### PR DESCRIPTION
- closes #366 
- closes #364

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the resolver version in the installation instructions for `eo-phi-normalizer`.

### Detailed summary
- Updated resolver version to `lts-22.16` in the installation command for `eo-phi-normalizer`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->