### PR TITLE
Release v0.4.0

### DIFF
--- a/eo-phi-normalizer/CHANGELOG.md
+++ b/eo-phi-normalizer/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to the
 
 ## v0.4.0 — 2024-06-03
 
-This version supports fast dataization with built-in rules and improves metrics with both built-in and Yegor's rules.
+This version supports fast dataization with built-in rules and improves metrics with both built-in and user-defined rules (via YAML).
 
 New:
 

--- a/eo-phi-normalizer/CHANGELOG.md
+++ b/eo-phi-normalizer/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.4.0 — 2024-06-03
+
+This version supports fast dataization with built-in rules and improves metrics with both built-in and Yegor's rules.
+
+New:
+
+- Add built-in rules
+- Add more built-in dataization functions ([#291](https://github.com/objectionary/normalizer/pull/291))
+- Support LaTeX format in output ([#308](https://github.com/objectionary/normalizer/pull/308))
+- Speed up pipeline by caching EO compilation results ([#340](https://github.com/objectionary/normalizer/pull/340))
+- Write generated PHI files as eo-phi-normalizer data files ([#286](https://github.com/objectionary/normalizer/pull/286))
+- Update and commit docs in CI ([#286](https://github.com/objectionary/normalizer/pull/286))
+
+Changes and fixes:
+
+- Switch to EO 0.38.0 ([#335](https://github.com/objectionary/normalizer/pull/335))
+- Remove VTX and Sigma ([#335](https://github.com/objectionary/normalizer/pull/335))
+- Fix normalization and dataization rules w.r.t. xi and rho (see [#297](https://github.com/objectionary/normalizer/pull/297))
+- Fix confluence tests ([#319](https://github.com/objectionary/normalizer/pull/319))
+- Fix pipeline tests ([#338](https://github.com/objectionary/normalizer/pull/338))
+- Integrate `transform-eo-tests` into normalizer ([#365](https://github.com/objectionary/normalizer/pull/365))
+- Switch to GHC 9.6.4 ([#263](https://github.com/objectionary/normalizer/pull/263))
+
+Documentation and maintenance:
+
+- Add the `Quick Start` page ([#317](https://github.com/objectionary/normalizer/pull/317))
+- Add the `Pipeline` page ([#261](https://github.com/objectionary/normalizer/pull/261))
+
 ## v0.3.1 — 2024-04-12
 
 This version supports proper dataization of test programs with dependencies.

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           eo-phi-normalizer
-version:        0.3.1
+version:        0.4.0
 synopsis:       Command line normalizer of 𝜑-calculus expressions.
 description:    Please see the README on GitHub at <https://github.com/objectionary/eo-phi-normalizer#readme>
 homepage:       https://github.com/objectionary/eo-phi-normalizer#readme

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -1,6 +1,6 @@
 name: eo-phi-normalizer
 synopsis: "Command line normalizer of 𝜑-calculus expressions."
-version: 0.3.1
+version: 0.4.0
 github: "objectionary/eo-phi-normalizer"
 license: BSD3
 author: "EO/Polystat Development Team"


### PR DESCRIPTION
Closes #378

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `eo-phi-normalizer` to version 0.4.0, focusing on adding built-in rules, improving dataization functions, supporting LaTeX output, and enhancing pipeline speed and caching.

### Detailed summary
- Added built-in rules
- Enhanced dataization functions
- Supported LaTeX format in output
- Improved pipeline speed with caching
- Updated to EO 0.38.0
- Removed VTX and Sigma
- Fixed normalization and dataization rules
- Integrated `transform-eo-tests`
- Switched to GHC 9.6.4
- Added `Quick Start` and `Pipeline` pages

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->