### PR TITLE
Fix dataization

### DIFF
--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax.hs
@@ -41,9 +41,9 @@ render d = rend 0 False (map ($ "") $ d []) ""
   rend i p = \case
     "[" : ts -> char '[' . rend i False ts
     "(" : ts -> char '(' . rend i False ts
-    -- "{"      :ts -> onNewLine i     p . showChar   '{'  . new (i+1) ts
+    "⟦" : ts -> showChar '⟦' . new (i + 1) ts
     -- "}" : ";":ts -> onNewLine (i-1) p . showString "};" . new (i-1) ts
-    -- "}"      :ts -> onNewLine (i-1) p . showChar   '}'  . new (i-1) ts
+    "⟧" : ts -> onNewLine (i - 1) p . showChar '⟧' . new (i - 1) ts
     [";"] -> char ';'
     ";" : ts -> char ';' . new i ts
     t : ts@(s : _)
@@ -85,3 +85,7 @@ render d = rend 0 False (map ($ "") $ d []) ""
 
   closerOrPunct :: String
   closerOrPunct = ")],;"
+
+  -- Make sure we are on a fresh line.
+  onNewLine :: Int -> Bool -> ShowS
+  onNewLine i p = (if p then id else showChar '\n') . indent i

--- a/eo-phi-normalizer/test/eo/phi/from-eo/as-phi.yaml
+++ b/eo-phi-normalizer/test/eo/phi/from-eo/as-phi.yaml
@@ -6,4 +6,18 @@ tests:
     normalized: |
       { ⟦ org ↦ ⟦ eolang ↦ ⟦ prints-itself ↦ ⟦ φ ↦ Φ.org.eolang.as-phi (α0 ↦ ξ).length.gt (α0 ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-00))) ⟧, prints-itself-to-console ↦ ⟦ x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ)) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧ ⟧ }
     prettified: |
-      { ⟦ org ↦ ⟦ eolang ↦ ⟦ prints-itself ↦ ⟦ φ ↦ Φ.org.eolang.as-phi (α0 ↦ ξ).length.gt (α0 ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-00))) ⟧, prints-itself-to-console ↦ ⟦ x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ)) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧ ⟧ }
+      { ⟦
+        org ↦ ⟦
+          eolang ↦ ⟦
+            prints-itself ↦ ⟦
+              φ ↦ Φ.org.eolang.as-phi (α0 ↦ ξ).length.gt (α0 ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-00)))
+            ⟧
+            , prints-itself-to-console ↦ ⟦
+              x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ))
+            ⟧
+            , λ ⤍ Package
+          ⟧
+          , λ ⤍ Package
+        ⟧
+      ⟧
+      }


### PR DESCRIPTION
- [x] Fix dataization inside $\varphi$ when `--minimize-stuck-terms` is enabled (closes #393)
- [x] Fix evaluation of atoms stuck on other atoms (fixes `while-dataizes-only-first-cycle` in `while-tests.phi`)
- [x] Improve pretty-printing (closes #292)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `Language.EO.Phi` module and improving dataization functions. 

### Detailed summary
- Replaced characters for better readability in `Syntax.hs`.
- Added `printTree` import in `Dataize.hs`.
- Updated evaluation functions with better error handling.
- Added comments for clarity and documentation.

> The following files were skipped due to too many changes: `eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->