### PR TITLE
390 fix normalized phi to normalized eo conversion in the pipeline script

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -425,7 +425,7 @@ wrapRawBytesIn = \case
     ObjectDispatch (wrapRawBytesIn obj) a
   GlobalObject -> GlobalObject
   ThisObject -> ThisObject
-  Termination -> Termination
+  Termination -> wrapTermination
   obj@MetaSubstThis{} -> obj
   obj@MetaObject{} -> obj
   obj@MetaFunction{} -> obj

--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -40,7 +40,7 @@ import Data.Text.Internal.Builder (toLazyText)
 import Data.Text.Lazy as TL (unpack)
 import Data.Yaml (decodeFileThrow)
 import GHC.Generics (Generic)
-import Language.EO.Phi (Binding (LambdaBinding), Bytes (Bytes), Object (Formation), Program (Program), parseProgram, printTree)
+import Language.EO.Phi (Binding (..), Bytes (Bytes), Object (..), Program (Program), parseProgram, printTree)
 import Language.EO.Phi.Dataize
 import Language.EO.Phi.Dependencies
 import Language.EO.Phi.Metrics.Collect as Metrics (getProgramMetrics)
@@ -85,6 +85,7 @@ data CLI'DataizePhi = CLI'DataizePhi
   , latex :: Bool
   , asPackage :: Bool
   , minimizeStuckTerms :: Bool
+  , wrapRawBytes :: Bool
   }
   deriving (Show)
 
@@ -231,6 +232,7 @@ commandParser =
     outputFile <- outputFileOption
     recursive <- switch (long "recursive" <> help "Apply dataization + normalization recursively.")
     chain <- switch (long "chain" <> help "Display all the intermediate steps.")
+    wrapRawBytes <- switch (long "wrap-raw-bytes" <> help "Wrap raw bytes ⟦ Δ ⤍ 01- ⟧ as Φ.org.eolang.bytes(Δ ⤍ 01-) in the final output.")
     latex <- latexSwitch
     asPackage <- asPackageSwitch
     minimizeStuckTerms <- minimizeStuckTermsSwitch
@@ -401,6 +403,33 @@ isLambdaPackage :: Binding -> Bool
 isLambdaPackage (LambdaBinding "Package") = True
 isLambdaPackage _ = False
 
+wrapRawBytesIn :: Object -> Object
+wrapRawBytesIn = \case
+  Formation [DeltaBinding bytes] -> wrapBytesInBytes bytes
+  Formation bindings ->
+    Formation
+      [ case binding of
+        AlphaBinding a obj -> AlphaBinding a (wrapRawBytesIn obj)
+        _ -> binding
+      | binding <- bindings
+      ]
+  Application obj bindings ->
+    Application
+      (wrapRawBytesIn obj)
+      [ case binding of
+        AlphaBinding a attached -> AlphaBinding a (wrapRawBytesIn attached)
+        _ -> binding
+      | binding <- bindings
+      ]
+  ObjectDispatch obj a ->
+    ObjectDispatch (wrapRawBytesIn obj) a
+  GlobalObject -> GlobalObject
+  ThisObject -> ThisObject
+  Termination -> Termination
+  obj@MetaSubstThis{} -> obj
+  obj@MetaObject{} -> obj
+  obj@MetaFunction{} -> obj
+
 -- * Main
 
 main :: IO ()
@@ -530,7 +559,10 @@ main = withUtf8 do
               let obj'
                     | asPackage = removeLambdaPackage obj
                     | otherwise = obj
-               in logStrLn (printAsProgramOrAsObject obj')
+                  obj''
+                    | wrapRawBytes = wrapRawBytesIn obj'
+                    | otherwise = obj'
+               in logStrLn (printAsProgramOrAsObject obj'')
             Right (Bytes bytes) -> logStrLn bytes
     CLI'ReportPhi' CLI'ReportPhi{..} -> do
       pipelineConfig <- decodeFileThrow @_ @PipelineConfig configFile

--- a/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
@@ -75,7 +75,7 @@ dataizeStepChain obj@(Formation bs)
   isEmpty _ = False
   hasEmpty = any isEmpty bs
 -- IMPORTANT: dataize the object being copied IF normalization is stuck on it!
-dataizeStepChain (Application obj@Formation{} bindings) = incLogLevel $ do
+dataizeStepChain (Application obj bindings) = incLogLevel $ do
   logStep "Dataizing inside application" (Left obj)
   modifyContext (\c -> c{dataizePackage = False}) $ do
     (ctx, obj') <- dataizeStepChain obj
@@ -83,7 +83,7 @@ dataizeStepChain (Application obj@Formation{} bindings) = incLogLevel $ do
       Left obj'' -> return (ctx, Left (obj'' `Application` bindings))
       Right bytes -> return (ctx, Left (Formation [DeltaBinding bytes] `Application` bindings))
 -- IMPORTANT: dataize the object being dispatched IF normalization is stuck on it!
-dataizeStepChain (ObjectDispatch obj@Formation{} attr) = incLogLevel $ do
+dataizeStepChain (ObjectDispatch obj attr) = incLogLevel $ do
   logStep "Dataizing inside dispatch" (Left obj)
   modifyContext (\c -> c{dataizePackage = False}) $ do
     (ctx, obj') <- dataizeStepChain obj

--- a/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
@@ -243,6 +243,10 @@ wrapBytesInString :: Bytes -> Object
 wrapBytesInString (Bytes bytes) = [fmt|Φ.org.eolang.string(as-bytes ↦ Φ.org.eolang.bytes(Δ ⤍ {bytes}))|]
 wrapBytesInBytes :: Bytes -> Object
 wrapBytesInBytes (Bytes bytes) = [fmt|Φ.org.eolang.bytes(Δ ⤍ {bytes})|]
+wrapTermination :: Object
+wrapTermination = [fmt|Φ.org.eolang.error(α0 ↦ Φ.org.eolang.string(as-bytes ↦ Φ.org.eolang.bytes(Δ ⤍ {bytes})))|]
+ where
+  Bytes bytes = stringToBytes "unknown error"
 
 wrapBytesAsBool :: Bytes -> Object
 wrapBytesAsBool bytes

--- a/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
@@ -321,7 +321,18 @@ evaluateBuiltinFunChain name@"Lorg_eolang_string_slice" obj = \state -> do
 -- I/O
 -- evaluateBuiltinFunChain name@"Lorg_eolang_io_stdin_next_line" obj = evaluateIODataizationFunChain getLine obj
 -- evaluateBuiltinFunChain name@"Lorg_eolang_io_stdin_φ" obj = evaluateIODataizationFunChain getContents obj
--- evaluateBuiltinFunChain name@"Lorg_eolang_io_stdout" obj = evaluateUnaryDataizationFunChain boolToBytes bytesToString wrapBytesInBytes (extractLabel "text") ((`seq` True) . unsafePerformIO . putStrLn) obj
+evaluateBuiltinFunChain name@"Lorg_eolang_io_stdout" obj = \state -> do
+  text <- incLogLevel $ dataizeRecursivelyChain True (extractLabel "text" obj)
+  let text' = case text of
+        Left textObj -> textObj
+        Right textBytes -> Formation [DeltaBinding textBytes]
+  return
+    ( Formation
+        [ AlphaBinding "text" text'
+        , LambdaBinding (Function name)
+        ]
+    , state
+    )
 -- others
 evaluateBuiltinFunChain name@"Lorg_eolang_dataized" obj =
   evaluateUnaryDataizationFunChain name id id wrapBytesInBytes (extractLabel "target") id obj

--- a/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
@@ -321,18 +321,7 @@ evaluateBuiltinFunChain name@"Lorg_eolang_string_slice" obj = \state -> do
 -- I/O
 -- evaluateBuiltinFunChain name@"Lorg_eolang_io_stdin_next_line" obj = evaluateIODataizationFunChain getLine obj
 -- evaluateBuiltinFunChain name@"Lorg_eolang_io_stdin_φ" obj = evaluateIODataizationFunChain getContents obj
-evaluateBuiltinFunChain name@"Lorg_eolang_io_stdout" obj = \state -> do
-  text <- incLogLevel $ dataizeRecursivelyChain True (extractLabel "text" obj)
-  let text' = case text of
-        Left textObj -> textObj
-        Right textBytes -> Formation [DeltaBinding textBytes]
-  return
-    ( Formation
-        [ AlphaBinding "text" text'
-        , LambdaBinding (Function name)
-        ]
-    , state
-    )
+-- evaluateBuiltinFunChain name@"Lorg_eolang_io_stdout" obj = evaluateUnaryDataizationFunChain boolToBytes bytesToString wrapBytesInBytes (extractLabel "text") ((`seq` True) . unsafePerformIO . putStrLn) obj
 -- others
 evaluateBuiltinFunChain name@"Lorg_eolang_dataized" obj =
   evaluateUnaryDataizationFunChain name id id wrapBytesInBytes (extractLabel "target") id obj

--- a/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
@@ -277,7 +277,7 @@ evaluateBuiltinFunChain :: String -> Object -> EvaluationState -> DataizeChain (
 evaluateBuiltinFunChain name@"Lorg_eolang_int_gt" obj = evaluateIntIntBoolFunChain name (>) obj
 evaluateBuiltinFunChain name@"Lorg_eolang_int_plus" obj = evaluateIntIntIntFunChain name (+) obj
 evaluateBuiltinFunChain name@"Lorg_eolang_int_times" obj = evaluateIntIntIntFunChain name (*) obj
-evaluateBuiltinFunChain name@"Lorg_eolang_int_div" obj = evaluateIntIntIntFunChain name div obj
+evaluateBuiltinFunChain name@"Lorg_eolang_int_div" obj = evaluateIntIntIntFunChain name quot obj
 -- bytes
 evaluateBuiltinFunChain name@"Lorg_eolang_bytes_eq" obj = evaluateBinaryDataizationFunChain name boolToBytes bytesToInt wrapBytesAsBool extractRho (extractLabel "b") (==) obj
 evaluateBuiltinFunChain name@"Lorg_eolang_bytes_size" obj = evaluateUnaryDataizationFunChain name intToBytes id wrapBytesInBytes extractRho (\(Bytes bytes) -> length (words (map dashToSpace bytes))) obj

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -510,12 +510,12 @@ bytesToInt (Bytes (dropWhile (== '0') . filter (/= '-') -> bytes))
 -- | Convert 'Bool' to 'Bytes'.
 --
 -- >>> boolToBytes False
--- Bytes "00-00-00-00-00-00-00-00"
+-- Bytes "00-"
 -- >>> boolToBytes True
--- Bytes "00-00-00-00-00-00-00-01"
+-- Bytes "01-"
 boolToBytes :: Bool -> Bytes
-boolToBytes True = intToBytes 1
-boolToBytes False = intToBytes 0
+boolToBytes True = Bytes "01-"
+boolToBytes False = Bytes "00-"
 
 -- | Interpret 'Bytes' as 'Bool'.
 --

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Common.hs
@@ -13,6 +13,7 @@ module Language.EO.Phi.Rules.Common where
 import Control.Applicative (Alternative ((<|>)), asum)
 import Control.Arrow (Arrow (first))
 import Control.Monad
+import Data.ByteString (ByteString)
 import Data.ByteString qualified as ByteString.Strict
 import Data.Char (toUpper)
 import Data.List (intercalate, minimumBy, nubBy, sortOn)
@@ -21,6 +22,8 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Ord (comparing)
 import Data.Serialize qualified as Serialize
 import Data.String (IsString (..))
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 import Language.EO.Phi.Syntax.Abs
 import Language.EO.Phi.Syntax.Lex (Token)
 import Language.EO.Phi.Syntax.Par
@@ -544,19 +547,29 @@ bytesToBool _ = True
 -- Bytes "48-65-6C-6C-6F-2C-20-77-6F-72-6C-64-21"
 --
 -- >>> stringToBytes "Привет, мир!"
--- Bytes "04-1F-44-04-38-43-24-35-44-22-C2-04-3C-43-84-40-21"
+-- Bytes "D0-9F-D1-80-D0-B8-D0-B2-D0-B5-D1-82-2C-20-D0-BC-D0-B8-D1-80-21"
+--
+-- >>> stringToBytes  "hello, 大家!"
+-- Bytes "68-65-6C-6C-6F-2C-20-E5-A4-A7-E5-AE-B6-21"
 stringToBytes :: String -> Bytes
-stringToBytes s = Bytes $ normalizeBytes $ foldMap (padLeft 2 . (`showHex` "") . fromEnum) s
+stringToBytes s = bytestringToBytes $ Text.encodeUtf8 (Text.pack s)
+
+bytestringToBytes :: ByteString -> Bytes
+bytestringToBytes = Bytes . normalizeBytes . foldMap (padLeft 2 . (`showHex` "")) . ByteString.Strict.unpack
+
+bytesToByteString :: Bytes -> ByteString
+bytesToByteString (Bytes bytes) = ByteString.Strict.pack (go (filter (/= '-') bytes))
+ where
+  go [] = []
+  go (x : y : xs) = fst (head (readHex [x, y])) : go xs
+  go [_] = error "impossible: partial byte"
 
 -- | Decode 'String' from 'Bytes'.
 --
 -- >>> bytesToString "48-65-6C-6C-6F-2C-20-77-6F-72-6C-64-21"
 -- "Hello, world!"
 bytesToString :: Bytes -> String
-bytesToString (Bytes bytes) = map (toEnum . fst . head . readHex) $ words (map dashToSpace bytes)
- where
-  dashToSpace '-' = ' '
-  dashToSpace c = c
+bytesToString = Text.unpack . Text.decodeUtf8 . bytesToByteString
 
 -- | Encode 'Double' as 'Bytes' following IEEE754.
 --

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
@@ -108,12 +108,10 @@ fastYegorInsideOut ctx = \case
         case argBindings' of
           [AlphaBinding (Alpha "α0") arg0, AlphaBinding (Alpha "α1") arg1] ->
             case filter isEmptyBinding bindings of
-              EmptyBinding a0 : EmptyBinding a1 : _ -> do
-                let arg0' = fastYegorInsideOut ctx arg0
-                let arg1' = fastYegorInsideOut ctx arg1
+              EmptyBinding a0 : EmptyBinding a1 : _ ->
                 Formation
-                  ( AlphaBinding a0 arg0'
-                      : AlphaBinding a1 arg1'
+                  ( AlphaBinding a0 arg0
+                      : AlphaBinding a1 arg1
                       : [ binding
                         | binding <- bindings
                         , case binding of
@@ -124,10 +122,9 @@ fastYegorInsideOut ctx = \case
               _ -> Application obj' argBindings'
           [AlphaBinding (Alpha "α0") arg0] ->
             case filter isEmptyBinding bindings of
-              EmptyBinding a0 : _ -> do
-                let arg0' = fastYegorInsideOut ctx arg0
+              EmptyBinding a0 : _ ->
                 Formation
-                  ( AlphaBinding a0 arg0'
+                  ( AlphaBinding a0 arg0
                       : [ binding
                         | binding <- bindings
                         , case binding of
@@ -137,9 +134,8 @@ fastYegorInsideOut ctx = \case
                   )
               _ -> Application obj' argBindings'
           [AlphaBinding a argA] | EmptyBinding a `elem` bindings -> do
-            let argA' = fastYegorInsideOut ctx argA
             Formation
-              ( AlphaBinding a argA'
+              ( AlphaBinding a argA
                   : [ binding
                     | binding <- bindings
                     , case binding of

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
@@ -108,6 +108,23 @@ fastYegorInsideOut ctx = \case
       obj'@(Formation bindings) -> do
         let argBindings' = map (fastYegorInsideOutBinding ctx) argBindings
         case argBindings' of
+          [AlphaBinding (Alpha "α0") arg0, AlphaBinding (Alpha "α1") arg1, AlphaBinding (Alpha "α2") arg2] ->
+            case filter isEmptyBinding bindings of
+              EmptyBinding a0 : EmptyBinding a1 : EmptyBinding a2 : _ ->
+                Formation
+                  ( AlphaBinding a0 arg0
+                      : AlphaBinding a1 arg1
+                      : AlphaBinding a2 arg2
+                      : [ binding
+                        | binding <- bindings
+                        , case binding of
+                            EmptyBinding x | x `elem` [a0, a1, a2] -> False
+                            _ -> True
+                        ]
+                  )
+              _
+                | not (any isLambdaBinding bindings) -> Termination
+                | otherwise -> Application obj' argBindings'
           [AlphaBinding (Alpha "α0") arg0, AlphaBinding (Alpha "α1") arg1] ->
             case filter isEmptyBinding bindings of
               EmptyBinding a0 : EmptyBinding a1 : _ ->

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
@@ -133,16 +133,17 @@ fastYegorInsideOut ctx = \case
                         ]
                   )
               _ -> Application obj' argBindings'
-          [AlphaBinding a argA] | EmptyBinding a `elem` bindings -> do
-            Formation
-              ( AlphaBinding a argA
-                  : [ binding
-                    | binding <- bindings
-                    , case binding of
-                        EmptyBinding x | x == a -> False
-                        _ -> True
-                    ]
-              )
+          [AlphaBinding a argA]
+            | EmptyBinding a `elem` bindings ->
+                Formation
+                  ( AlphaBinding a argA
+                      : [ binding
+                        | binding <- bindings
+                        , case binding of
+                            EmptyBinding x | x == a -> False
+                            _ -> True
+                        ]
+                  )
           [DeltaBinding bytes] | DeltaEmptyBinding `elem` bindings -> do
             Formation
               ( DeltaBinding bytes

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs
@@ -3,8 +3,6 @@
 
 module Language.EO.Phi.Rules.Fast where
 
--- import Debug.Trace (trace)
-
 import Data.List.NonEmpty qualified as NonEmpty
 import Language.EO.Phi.Rules.Common
 import Language.EO.Phi.Rules.Yaml qualified as Yaml
@@ -133,7 +131,7 @@ fastYegorInsideOut ctx = \case
                         ]
                   )
               _ -> Application obj' argBindings
-          [AlphaBinding a argA] -> do
+          [AlphaBinding a argA] | EmptyBinding a `elem` bindings -> do
             let argA' = fastYegorInsideOut ctx argA
             Formation
               ( AlphaBinding a argA'
@@ -144,7 +142,7 @@ fastYegorInsideOut ctx = \case
                         _ -> True
                     ]
               )
-          [DeltaBinding bytes] -> do
+          [DeltaBinding bytes] | DeltaEmptyBinding `elem` bindings -> do
             Formation
               ( DeltaBinding bytes
                   : [ binding

--- a/eo-phi-normalizer/src/Language/EO/Phi/Syntax.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Syntax.hs
@@ -41,8 +41,11 @@ render d = rend 0 False (map ($ "") $ d []) ""
   rend i p = \case
     "[" : ts -> char '[' . rend i False ts
     "(" : ts -> char '(' . rend i False ts
+    "{" : "⟦" : ts -> showString "{⟦" . new (i + 1) ts
     "⟦" : ts -> showChar '⟦' . new (i + 1) ts
-    -- "}" : ";":ts -> onNewLine (i-1) p . showString "};" . new (i-1) ts
+    ")" : "," : ts -> showString ")," . new i ts
+    "⟧" : "," : ts -> onNewLine (i - 1) p . showString "⟧," . new (i - 1) ts
+    ["⟧", "}"] -> onNewLine (i - 1) p . showString "⟧}"
     "⟧" : ts -> onNewLine (i - 1) p . showChar '⟧' . new (i - 1) ts
     [";"] -> char ';'
     ";" : ts -> char ';' . new i ts

--- a/eo-phi-normalizer/test/eo/phi/from-eo/as-phi.yaml
+++ b/eo-phi-normalizer/test/eo/phi/from-eo/as-phi.yaml
@@ -6,18 +6,18 @@ tests:
     normalized: |
       { ⟦ org ↦ ⟦ eolang ↦ ⟦ prints-itself ↦ ⟦ φ ↦ Φ.org.eolang.as-phi (α0 ↦ ξ).length.gt (α0 ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-00))) ⟧, prints-itself-to-console ↦ ⟦ x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ)) ⟧, λ ⤍ Package ⟧, λ ⤍ Package ⟧ ⟧ }
     prettified: |
-      { ⟦
+      {⟦
         org ↦ ⟦
           eolang ↦ ⟦
             prints-itself ↦ ⟦
               φ ↦ Φ.org.eolang.as-phi (α0 ↦ ξ).length.gt (α0 ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-00)))
-            ⟧
-            , prints-itself-to-console ↦ ⟦
-              x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)), φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ))
-            ⟧
-            , λ ⤍ Package
-          ⟧
-          , λ ⤍ Package
+            ⟧,
+            prints-itself-to-console ↦ ⟦
+              x ↦ Φ.org.eolang.int (α0 ↦ Φ.org.eolang.bytes (Δ ⤍ 00-00-00-00-00-00-00-2A)),
+              φ ↦ Φ.org.eolang.io.stdout (α0 ↦ Φ.org.eolang.as-phi (α0 ↦ ξ))
+            ⟧,
+            λ ⤍ Package
+          ⟧,
+          λ ⤍ Package
         ⟧
-      ⟧
-      }
+      ⟧}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "devDependencies": {
-                "eolang": "^0.19.0",
+                "eolang": "^0.21.0",
                 "prettier": "^3.2.5"
             }
         },
@@ -50,6 +50,31 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
+        },
+        "node_modules/axios": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "dev": true,
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "form-data": "^4.0.0",
+                "proxy-from-env": "^1.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -156,10 +181,24 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/eo2js": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/eo2js/-/eo2js-0.0.7.tgz",
+            "integrity": "sha512-+JhyDtl+762yZXQJPd3Uhyt6whvrdYig0ivvwyW/jvFukbanL16j81nl43h5J69YEV3o0FouESxgghoGW/aEVw==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^12.0.0",
+                "fast-xml-parser": "^4.3.5",
+                "saxon-js": "^2.6.0"
+            },
+            "bin": {
+                "eo2js": "src/eo2js.js"
+            }
+        },
         "node_modules/eolang": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/eolang/-/eolang-0.19.0.tgz",
-            "integrity": "sha512-++6A6TDClT2WRZf7DZZhXa7WiuiF4KEbPvlhF94vL8dstb/u+E/K6ku1Son+mz+PfV4xqtKY8zTJZ2iG6cXX5A==",
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/eolang/-/eolang-0.21.0.tgz",
+            "integrity": "sha512-gfG5+CSE4ATqrXKgqD7HX5AB1smSM/Eze2maPalkPgcziHcb2VbLM5RDaWZh8KgRZ493fD+/EDpIrE0PBZcr7g==",
             "dev": true,
             "os": [
                 "darwin",
@@ -169,10 +208,11 @@
             "dependencies": {
                 "colors": "1.4.0",
                 "commander": "12.0.0",
-                "fast-xml-parser": "4.3.6",
-                "node": "21.7.3",
+                "eo2js": "0.0.7",
+                "fast-xml-parser": "4.4.0",
+                "node": "22.1.0",
                 "relative": "3.0.2",
-                "semver": "7.6.0",
+                "semver": "7.6.2",
                 "sync-request": "6.1.0",
                 "xmlhttprequest": "1.8.0"
             },
@@ -194,9 +234,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
-            "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+            "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
             "dev": true,
             "funding": [
                 {
@@ -213,6 +253,26 @@
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
             }
         },
         "node_modules/form-data": {
@@ -374,18 +434,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -408,9 +456,9 @@
             }
         },
         "node_modules/node": {
-            "version": "21.7.3",
-            "resolved": "https://registry.npmjs.org/node/-/node-21.7.3.tgz",
-            "integrity": "sha512-ouAXROl1nmh9mAZvejCfOnBp7CnRk14CCuBjZSIyDjv3da78m0nImWYlDRrPcgikBl2LHvvYq5BvDWfpfHoMtQ==",
+            "version": "22.1.0",
+            "resolved": "https://registry.npmjs.org/node/-/node-22.1.0.tgz",
+            "integrity": "sha512-eeRKoLhxcx3DEzsdU1XxbJlDfVX2rvobe24YT9+jzXa5heKMCadyWjYwAEgevi1+r4WU/weKr5DUoNJbI5OKmw==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -474,6 +522,12 @@
                 "asap": "~2.0.6"
             }
         },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "dev": true
+        },
         "node_modules/qs": {
             "version": "6.11.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
@@ -522,14 +576,20 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
-        "node_modules/semver": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+        "node_modules/saxon-js": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/saxon-js/-/saxon-js-2.6.0.tgz",
+            "integrity": "sha512-4dinQEGz/OQX0cnmwLTbjVFY9KciMGRyfA6AUsMCO/mKDOwDxOJFmzoLStieTpEiOB/98E1E4VKV1ElsiD88yQ==",
             "dev": true,
             "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+                "axios": "^1.5.1"
+            }
+        },
+        "node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -658,12 +718,6 @@
             "engines": {
                 "node": ">=0.4.0"
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
         }
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "eolang": "^0.19.0",
+        "eolang": "^0.21.0",
         "prettier": "^3.2.5"
     }
 }

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -117,6 +117,7 @@ function normalize {
             --minimize-stuck-terms \
             --as-package \
             --recursive \
+            --wrap-raw-bytes \
             $dependency_file_options \
             "$f" \
             > "$destination" \

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -145,6 +145,7 @@ function convert_normalized_phi_to_eo {
 
     cd "$PIPELINE_PHI_NORMALIZED_DIR"
     cp -r "$PIPELINE_EO_FILTERED_DIR/.eoc" .
+    cp -r ./!(.eoc) .eoc/phi
     eo unphi --tests
     cp -r .eoc/unphi/!(org) .eoc/2-optimize
     eo print
@@ -158,7 +159,7 @@ function test_with_normalization {
     mkdir_clean "$PIPELINE_EO_NORMALIZED_DIR"
 
     cd "$PIPELINE_EO_NORMALIZED_DIR"
-    cp -r "$PIPELINE_PHI_NORMALIZED_DIR"/.eoc/print/!(org)  .
+    cp -r "$PIPELINE_PHI_NORMALIZED_DIR"/.eoc/print/!(org) .
     test_with_logs "$PIPELINE_TEST_EO_NORMALIZED_LOGS"
     cd "$PIPELINE_DIR"
 }

--- a/scripts/try-unphi.sh
+++ b/scripts/try-unphi.sh
@@ -70,9 +70,9 @@ function unphi {
     cd "$TMP_DIR"
 
     cp -r "$INIT_DIR/.eoc" .
-    cp -r "$INPUT_DIR/*" .eoc/phi
+    cp -r "$INPUT_DIR"/* .eoc/phi
 
-    eo unphi
+    eo unphi --tests
 
     cp -r .eoc/unphi/!(org) .eoc/2-optimize
 

--- a/site/docs/src/contributing.md
+++ b/site/docs/src/contributing.md
@@ -50,6 +50,7 @@ Available commands:
   dataize                  Dataize a PHI program.
   report                   Generate reports about initial and normalized PHI
                            programs.
+  prepare-pipeline-tests   Prepare EO test files for the pipeline.
 ```
 
 Or, omit the executable name.
@@ -72,6 +73,7 @@ Available commands:
   dataize                  Dataize a PHI program.
   report                   Generate reports about initial and normalized PHI
                            programs.
+  prepare-pipeline-tests   Prepare EO test files for the pipeline.
 ```
 
 ## Test

--- a/site/docs/src/normalizer/report.md
+++ b/site/docs/src/normalizer/report.md
@@ -80,7 +80,7 @@ Usage: normalizer report (-c|--config FILE)
   Generate reports about initial and normalized PHI programs.
 
 Available options:
-  -c,--config FILE         A report configuration FILE.
+  -c,--config FILE         The FILE with a report configuration.
   -h,--help                Show this help text
 ```
 

--- a/site/docs/src/normalizer/transform.md
+++ b/site/docs/src/normalizer/transform.md
@@ -66,7 +66,7 @@ normalizer transform --help
 ```
 
 ```console
-Usage: normalizer transform (-r|--rules FILE) [-c|--chain] [-j|--json] [--tex]
+Usage: normalizer transform (-r|--rules FILE) [-c|--chain] [-j|--json]
                             [-o|--output-file FILE] [-s|--single]
                             [--max-depth INT] [--max-growth-factor INT] [FILE]
                             [-d|--dependency-file FILE]
@@ -77,7 +77,6 @@ Available options:
   -r,--rules FILE          FILE with user-defined rules. Must be specified.
   -c,--chain               Output transformation steps.
   -j,--json                Output JSON.
-  --tex                    Output LaTeX.
   -o,--output-file FILE    Output to FILE. When this option is not specified,
                            output to stdout.
   -s,--single              Output a single expression.
@@ -106,10 +105,10 @@ normalizer transform --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor.yaml ce
 ```console
 Rule set based on Yegor's draft
 Input:
-{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }
+{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }
 ====================================================
 Result 1 out of 1:
-{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }
+{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }
 ----------------------------------------------------
 ```
 
@@ -124,10 +123,10 @@ normalizer transform --chain --rules ./eo-phi-normalizer/test/eo/phi/rules/yegor
 ```console
 Rule set based on Yegor's draft
 Input:
-{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }
+{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }
 ====================================================
 Result 1 out of 1:
-[ 1 / 1 ] Normal form: { ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }
+[ 1 / 1 ] Normal form: { ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }
 ----------------------------------------------------
 ```
 
@@ -139,12 +138,12 @@ normalizer transform --json --chain --rules ./eo-phi-normalizer/test/eo/phi/rule
 
 ```json
 {
-  "input": "{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }",
+  "input": "{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }",
   "output": [
     [
       [
         "Normal form",
-        "{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }"
+        "{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }"
       ]
     ]
   ]
@@ -158,7 +157,7 @@ normalizer transform --single --rules ./eo-phi-normalizer/test/eo/phi/rules/yego
 ```
 
 ```console
-{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }
+{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }
 ```
 
 ### `--single` `--json`
@@ -168,7 +167,7 @@ normalizer transform --single --json --rules ./eo-phi-normalizer/test/eo/phi/rul
 ```
 
 ```console
-"{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }"
+"{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }"
 ```
 
 ### `--output-file FILE`
@@ -187,5 +186,5 @@ cat celsius.phi | normalizer transform --single --json --rules ./eo-phi-normaliz
 ```
 
 ```console
-"{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-19-FF-FF-FF-FF-FF-FF-FF-D0)), φ ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-CD-CC-CC-CC-CC-CC-1C-FF-FF-FF-FF-FF-FF-FF-CC ⟧).plus (x ↦ ⟦ Δ ⤍ 01-01-00-00-00-00-00-00-00-07-00-00-00-00-00-00-10-FF-FF-FF-FF-FF-FF-FF-D1 ⟧) ⟧ }"
+"{ ⟦ c ↦ Φ.org.eolang.float (as-bytes ↦ Φ.org.eolang.bytes (Δ ⤍ 40-39-00-00-00-00-00-00)), result ↦ ξ.c.times (x ↦ ⟦ Δ ⤍ 3F-FC-CC-CC-CC-CC-CC-CD ⟧).plus (x ↦ ⟦ Δ ⤍ 40-40-00-00-00-00-00-00 ⟧), λ ⤍ Package ⟧ }"
 ```

--- a/site/docs/src/quick-start.md
+++ b/site/docs/src/quick-start.md
@@ -16,5 +16,14 @@ normalizer dataize --recursive --rules eo-phi-normalizer/test/eo/phi/rules/yegor
 ```
 
 ```console
-{ ⟦ c ↦ ⟦ Δ ⤍ 40-39-00-00-00-00-00-00 ⟧, result ↦ ⟦ Δ ⤍ 40-53-40-00-00-00-00-00 ⟧, λ ⤍ Package ⟧ }
+{ ⟦
+  c ↦ ⟦
+    Δ ⤍ 40-39-00-00-00-00-00-00
+  ⟧
+  , result ↦ ⟦
+    Δ ⤍ 40-53-40-00-00-00-00-00
+  ⟧
+  , λ ⤍ Package
+⟧
+}
 ```

--- a/site/docs/src/quick-start.md
+++ b/site/docs/src/quick-start.md
@@ -12,7 +12,7 @@ Dataize the program recursively.
 normalizer dataize --recursive --rules eo-phi-normalizer/test/eo/phi/rules/yegor.yaml \
   --dependency-file 'eo-phi-normalizer/data/0.38.0/org/eolang/float.phi' \
   --dependency-file 'eo-phi-normalizer/data/0.38.0/org/eolang/bytes.phi' \
-  celcius.phi
+  celsius.phi
 ```
 
 ```console


### PR DESCRIPTION
Closes #390.

Also fixes some tests and improves a few things:
- [x] Add `--wrap-raw-bytes` to automatically convert raw bytes (and terminations) in the output. This is a temporary fix, pending the change mentioned in https://github.com/objectionary/eo/issues/3213#issuecomment-2150032168
- [x] Fix builtin normalizer to produce termination in some situations
- [x] Fix dataization inside application/dispatch
- [x] Fix encoding for strings to follow UTF-8 (compatibility with EO)
- [x] Fix bool representation to require one byte (compatibility with EO)
- [x] Fix integer division to truncate toward zero (compatibility with EO)
- [x] Improve pretty-printer (use indentation)
- [x] Update some examples/docs on the site
- [x] Support up to 3 positional arguments in the builtin normalizer
- [ ] Non-IO support for `Lorg_eolang_io_stdout` is NOT implemented, pending response to https://github.com/objectionary/eo/issues/3213#issuecomment-2151115865

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dependencies, adds command options, modifies file paths, and refactors code for better readability and functionality.

### Detailed summary
- Updated `eolang` dependency to version `0.21.0`.
- Added `--tests` option to the `eo unphi` command.
- Modified file paths in the `try-unphi.sh` script.
- Updated options in `report.md` and `quick-start.md`.
- Added `prepare-pipeline-tests` command.
- Refactored code for better object wrapping and dataization.
- Improved functions for handling bytes and strings.

> The following files were skipped due to too many changes: `eo-phi-normalizer/src/Language/EO/Phi/Rules/Fast.hs`, `package-lock.json`, `site/docs/src/normalizer/transform.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->