### PR TITLE
Bring rules up to date

### DIFF
--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -24,7 +24,7 @@ rules:
   #       input: '⟦ a ↦ ⟦ b ↦ ⟦ ⟧ ⟧ ⟧'
   #       output: []
 
-  - name: Rule 4
+  - name: Φ-dispatch
     description: 'Φ-dispatch'
     context:
       global_object: ⟦ !a ↦ !obj, !B ⟧
@@ -36,7 +36,7 @@ rules:
       - apply_in_subformations: false
     tests: []
 
-  - name: Rule 5
+  - name: ξ-dispatch
     description: 'ξ-dispatch'
     context:
       current_object: '!obj'
@@ -55,7 +55,7 @@ rules:
         output: []
       # How to test replacing without already having context?
 
-  - name: Rule 6
+  - name: R_DOT
     description: 'Accessing an α-binding'
     pattern: |
       ⟦ !a ↦ !n, !B ⟧.!a
@@ -72,22 +72,22 @@ rules:
         input: ⟦ ⟧.hello
         output: []
 
-  - name: Rule 6a
-    description: 'Accessing an α-binding (for object with ρ ↦ ∅)'
-    pattern: |
-      ⟦ !a ↦ !n, ρ ↦ ∅, !B ⟧.!a
-    result: |
-      !n[ ξ ↦ ⟦ !a ↦ !n, ρ ↦ ∅, !B ⟧ ]
-    when: []
-    tests:
-      - name: Should match
-        input: ⟦ hello ↦ ⟦⟧, ρ ↦ ∅ ⟧.hello
-        output: ['⟦ ρ ↦ ⟦ hello ↦ ⟦⟧, ρ ↦ ∅ ⟧ ⟧']
-      - name: Shouldn't match
-        input: ⟦ ⟧.hello
-        output: []
+  # - name: Rule 6a
+  #   description: 'Accessing an α-binding (for object with ρ ↦ ∅)'
+  #   pattern: |
+  #     ⟦ !a ↦ !n, ρ ↦ ∅, !B ⟧.!a
+  #   result: |
+  #     !n[ ξ ↦ ⟦ !a ↦ !n, ρ ↦ ∅, !B ⟧ ]
+  #   when: []
+  #   tests:
+  #     - name: Should match
+  #       input: ⟦ hello ↦ ⟦⟧, ρ ↦ ∅ ⟧.hello
+  #       output: ['⟦ ρ ↦ ⟦ hello ↦ ⟦⟧, ρ ↦ ∅ ⟧ ⟧']
+  #     - name: Shouldn't match
+  #       input: ⟦ ⟧.hello
+  #       output: []
 
-  - name: Rule 7 α0 α1
+  - name: R_COPY2
     description: 'Application of α-binding'
     # Warning: this is not correct for the chain variant because it only matches the first two bindings
     # i.e., doesn't match an empty binding after an attached one.
@@ -101,7 +101,7 @@ rules:
       - nf: '!n1'
     tests: []
 
-  - name: Rule 7 α0
+  - name: R_COPY1
     description: 'Application of α-binding'
     # Warning: this is not correct for the chain variant because it only matches the first binding
     # i.e., doesn't match an empty binding after an attached one.
@@ -114,7 +114,7 @@ rules:
       - nf: '!n'
     tests: []
 
-  - name: Rule 7a
+  - name: R_COPY
     description: 'Application of α-binding'
     pattern: |
       ⟦ !a ↦ ∅, !B ⟧(!a ↦ !n)
@@ -124,7 +124,7 @@ rules:
       - nf: '!n'
     tests: []
 
-  - name: Rule 7b
+  - name: R_COPY_Δ
     description: 'Application of Δ-binding'
     pattern: |
       ⟦ Δ ⤍ ∅, !B ⟧(Δ ⤍ !bytes)
@@ -133,7 +133,7 @@ rules:
     when: []
     tests: []
 
-  - name: Rule 8
+  - name: R_φ
     description: 'Accessing a decorated object'
     pattern: |
       ⟦ φ ↦ !n, !B ⟧.!a
@@ -154,26 +154,7 @@ rules:
         input: '⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧.a'
         output: []
 
-  - name: Rule 9a
-    description: 'Parent application (for existing parent)'
-    pattern: ⟦ ρ ↦ !t, !B ⟧(ρ ↦ !n)
-    result: ⟦ ρ ↦ !n, !B ⟧
-    when:
-      - nf: '!n'
-    tests: []
-
-  - name: Rule 9b
-    description: 'Parent application (without an existing parent)'
-    pattern: '⟦ !B ⟧(ρ ↦ !n)'
-    result: ⟦ ρ ↦ !n, !B ⟧
-    when:
-      - nf: '!n'
-      - absent_attrs:
-          attrs: ['ρ']
-          bindings: ['!B']
-    tests: []
-
-  - name: Rule 10
+  - name: R_MISS
     description: 'Invalid application'
     pattern: ⟦ !t ↦ !b1, !B1 ⟧(!t ↦ !b2, !B2)
     result: ⊥
@@ -184,7 +165,7 @@ rules:
         input: '⟦ t ↦ ⟦ a ↦ ∅ ⟧ ⟧(t ↦ ⟦ b ↦ ∅ ⟧)'
         output: ['⊥']
 
-  - name: Rule 11
+  - name: R_STOP
     description: 'Invalid attribute access'
     pattern: |
       ⟦ !B ⟧.!a
@@ -203,7 +184,7 @@ rules:
         input: '⟦ ρ ↦ ⟦ ⟧ ⟧.x'
         output: ['⊥']
 
-  - name: Rule 12
+  - name: R_DD
     description: 'Accessing an attribute on bottom'
     pattern: |
       ⊥.!a
@@ -218,7 +199,7 @@ rules:
         input: '⟦ ⟧.a'
         output: []
 
-  - name: Extra rule for bottom
+  - name: R_DC
     description: 'Application on bottom is bottom'
     pattern: |
       ⊥(!B)


### PR DESCRIPTION
- Add rule names;
- Delete parent application rules;
- Comment out 6a because the tests pass.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates rule names and descriptions in the `yegor.yaml` file under `eo-phi-normalizer/test/eo/phi/rules`. 

### Detailed summary
- Renamed rules from English to Greek letters
- Updated rule descriptions and names for clarity
- Removed irrelevant rules for improved code readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->