### PR TITLE
411 Fix report directory

### DIFF
--- a/.github/workflows/ghc.yml
+++ b/.github/workflows/ghc.yml
@@ -270,12 +270,22 @@ jobs:
           # we can't use caches because we can't overwrite them
           name: pipeline-files-${{ runner.os }}
           overwrite: true
+          # Problem
+          #
+          # The action doesn't save the pipeline directory.
+          # It saves just the content of this directory.
+          #
+          # Seems like the wildcard case (https://github.com/actions/upload-artifact#upload-using-multiple-paths-and-exclusions)
+          # is triggered when there are no paths that don't start with "pipeline"
+          #
+          # I added a dummy path to not trigger the wildcard case
           path: |
             pipeline
             !pipeline/**/.eoc
             !pipeline/eo-yaml
             pipeline/eo-initial/.eoc/4-pull/org/
             pipeline/phi-initial/.eoc/phi/org
+            dummy
 
       - name: Write about the artifact in the job summary
         if: always()


### PR DESCRIPTION
- Closes #411

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to address an issue where the GitHub action was not saving the entire pipeline directory. It adds a dummy path to prevent triggering a wildcard case.

### Detailed summary
- Added a dummy path to prevent triggering wildcard case for artifact upload
- Ensured saving entire pipeline directory instead of just content

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->