### PR TITLE
Release v0.4.1

### DIFF
--- a/eo-phi-normalizer/CHANGELOG.md
+++ b/eo-phi-normalizer/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v0.4.1 — 2024-06-12
+
+Changes and fixes:
+
+- Undo injection of top-level Package lambda ([#392](https://github.com/objectionary/normalizer/pull/392))
+- Fix dataization ([#395](https://github.com/objectionary/normalizer/pull/395))
+- Fix normalized phi to normalized eo conversion in the pipeline script ([#396](https://github.com/objectionary/normalizer/pull/396))
+- Fix job summary ([#402](https://github.com/objectionary/normalizer/pull/402))
+
+Documentation and maintenance:
+
+- Bring rules up to date ([#401](https://github.com/objectionary/normalizer/pull/401))
+
 ## v0.4.0 — 2024-06-03
 
 This version supports fast dataization with built-in rules and improves metrics with both built-in and user-defined rules (via YAML).

--- a/eo-phi-normalizer/CHANGELOG.md
+++ b/eo-phi-normalizer/CHANGELOG.md
@@ -31,7 +31,7 @@ Changes and fixes:
 
 - Fix directory used in CI for:
   - Job summary ([#402](https://github.com/objectionary/normalizer/pull/402))
-  - Report ([412](https://github.com/objectionary/normalizer/pull/412))
+  - Report ([#412](https://github.com/objectionary/normalizer/pull/412))
 
 Documentation and maintenance:
 

--- a/eo-phi-normalizer/CHANGELOG.md
+++ b/eo-phi-normalizer/CHANGELOG.md
@@ -12,12 +12,31 @@ Changes and fixes:
 
 - Undo injection of top-level Package lambda ([#392](https://github.com/objectionary/normalizer/pull/392))
 - Fix dataization ([#395](https://github.com/objectionary/normalizer/pull/395))
-- Fix normalized phi to normalized eo conversion in the pipeline script ([#396](https://github.com/objectionary/normalizer/pull/396))
-- Fix job summary ([#402](https://github.com/objectionary/normalizer/pull/402))
+  - Fix dataization inside $\varphi$ when `--minimize-stuck-terms` is enabled (closes [#393](https://github.com/objectionary/normalizer/pull/393))
+  - Fix evaluation of atoms stuck on other atoms (fixes `while-dataizes-only-first-cycle` in `while-tests.phi`)
+  - Improve pretty-printing (closes [#292](https://github.com/objectionary/normalizer/pull/292))
+
+- Fix pipeline script to run tests on normalized EO ([#396](https://github.com/objectionary/normalizer/pull/396))
+
+- Changes to normalizer ([#396](https://github.com/objectionary/normalizer/pull/396))
+  - Add `--wrap-raw-bytes` to automatically convert raw bytes (and terminations) in the output. This is a temporary fix, pending the change mentioned in <https://github.com/objectionary/eo/issues/3213#issuecomment-2150032168>
+  - Fix builtin normalizer to produce termination in some situations
+  - Fix dataization inside application/dispatch
+  - Fix encoding for strings to follow UTF-8 (compatibility with EO)
+  - Fix bool representation to require one byte (compatibility with EO)
+  - Fix integer division to truncate toward zero (compatibility with EO)
+  - Improve pretty-printer (use indentation)
+  - Update some examples/docs on the site
+  - Support up to 3 positional arguments in the builtin normalizer
+
+- Fix directory used in CI for:
+  - Job summary ([#402](https://github.com/objectionary/normalizer/pull/402))
+  - Report ([412](https://github.com/objectionary/normalizer/pull/412))
 
 Documentation and maintenance:
 
 - Bring rules up to date ([#401](https://github.com/objectionary/normalizer/pull/401))
+- Update dependency prettier to v3.3.2 ([#385](https://github.com/objectionary/normalizer/pull/385))
 
 ## v0.4.0 — 2024-06-03
 

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           eo-phi-normalizer
-version:        0.4.0
+version:        0.4.1
 synopsis:       Command line normalizer of 𝜑-calculus expressions.
 description:    Please see the README on GitHub at <https://github.com/objectionary/eo-phi-normalizer#readme>
 homepage:       https://github.com/objectionary/eo-phi-normalizer#readme
@@ -22,6 +22,7 @@ extra-source-files:
     grammar/EO/Phi/Syntax.cf
     report/main.js
     report/styles.css
+    data/0.36.0/0.36.0.md
     data/0.36.0/org/eolang/as-phi.phi
     data/0.36.0/org/eolang/bool.phi
     data/0.36.0/org/eolang/bytes.phi
@@ -51,6 +52,7 @@ extra-source-files:
     data/0.36.0/org/eolang/try.phi
     data/0.36.0/org/eolang/tuple.phi
     data/0.36.0/org/eolang/while.phi
+    data/0.37.0/0.37.0.md
     data/0.37.0/org/eolang/as-phi.phi
     data/0.37.0/org/eolang/bytes.phi
     data/0.37.0/org/eolang/cage.phi
@@ -75,6 +77,7 @@ extra-source-files:
     data/0.37.0/org/eolang/try.phi
     data/0.37.0/org/eolang/tuple.phi
     data/0.37.0/org/eolang/while.phi
+    data/0.38.0/0.38.0.md
     data/0.38.0/org/eolang/as-phi.phi
     data/0.38.0/org/eolang/bytes.phi
     data/0.38.0/org/eolang/cage.phi

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -1,6 +1,6 @@
 name: eo-phi-normalizer
 synopsis: "Command line normalizer of 𝜑-calculus expressions."
-version: 0.4.0
+version: 0.4.1
 github: "objectionary/eo-phi-normalizer"
 license: BSD3
 author: "EO/Polystat Development Team"


### PR DESCRIPTION
- Closes #410

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `eo-phi-normalizer` package to version 0.4.1, introducing fixes and improvements to dataization, pretty-printing, normalization, and compatibility with EO language.

### Detailed summary
- Undo injection of top-level Package lambda
- Fix dataization
- Fix dataization inside $\varphi$ with `--minimize-stuck-terms`
- Fix evaluation of atoms stuck on other atoms
- Improve pretty-printing
- Fix pipeline script for running tests on normalized EO
- Add `--wrap-raw-bytes` option
- Fix builtin normalizer for termination
- Fix dataization inside application/dispatch
- Fix encoding for strings to follow UTF-8
- Fix bool representation to require one byte
- Fix integer division to truncate toward zero
- Update examples/docs on the site
- Support up to 3 positional arguments in the builtin normalizer
- Fix CI directory for job summary and report
- Bring rules up to date
- Update dependency prettier to v3.3.2

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->