### PR TITLE
Align reductions from application to `⊥` with the paper

### DIFF
--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -165,6 +165,29 @@ rules:
         input: '⟦ t ↦ ⟦ a ↦ ∅ ⟧ ⟧(t ↦ ⟦ b ↦ ∅ ⟧)'
         output: ['⊥']
 
+  - name: R_OVER
+    description: 'Invalid application (attribute already attached)'
+    pattern: ⟦ !t ↦ !b1, !B1 ⟧(!t ↦ !b2, !B2)
+    result: ⊥
+    when: []
+    tests:
+      - name: ''
+        input: '⟦ t ↦ ⟦ a ↦ ∅ ⟧ ⟧(t ↦ ⟦ b ↦ ∅ ⟧)'
+        output: ['⊥']
+
+  - name: R_MISS
+    description: 'Invalid application (absent attribute)'
+    pattern: ⟦ !B1 ⟧(!t ↦ !b2, !B2)
+    result: ⊥
+    when:
+      - absent_attrs:
+          attrs: ['!t', 'φ', 'λ']
+          bindings: ['!B1']
+    tests:
+      - name: ''
+        input: '⟦ t1 ↦ ⟦ a ↦ ∅ ⟧ ⟧(t ↦ ⟦ b ↦ ∅ ⟧)'
+        output: ['⊥']
+
   - name: R_STOP
     description: 'Invalid attribute access'
     pattern: |


### PR DESCRIPTION
In the paper, there are two rules regarding reductions from application to `⊥`:
- in case the attribute is already attached, and
- if the attribute is missing.

This PR brings these two rules into `yegor.yaml`. Currently, we have just `R_OVER`, which is named `R_MISS`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces new YAML rules for normalizing phi expressions in the eo-phi-normalizer module.

### Detailed summary
- Added a new rule `R_OVER` for handling invalid application with attribute already attached
- Added a new rule `R_MISS` for handling invalid application with absent attribute
- Removed the rule `R_STOP` for invalid attribute access

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->