### PR TITLE
Update decoration rule

### DIFF
--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -136,11 +136,13 @@ rules:
   - name: R_φ
     description: 'Accessing a decorated object'
     pattern: |
-      ⟦ φ ↦ !n, !B ⟧.!a
+      ⟦!B ⟧.!a
     result: |
-      ⟦ φ ↦ !n, !B ⟧.φ.!a
+      ⟦!B ⟧.φ.!a
     when:
-      - not_equal: ['!a', 'φ']
+      - present_attrs:
+          attrs: ['φ']
+          bindings: ['!B']
       - absent_attrs:
           attrs: ['!a']
           bindings: ['!B']

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -138,10 +138,8 @@ rules:
     pattern: |
       ⟦ φ ↦ !n, !B ⟧.!a
     result: |
-      !n[ ξ ↦ ⟦ φ ↦ !n, !B ⟧ ].!a
+      ⟦ φ ↦ !n, !B ⟧.φ.!a
     when:
-      - apply_in_subformations: false
-      - nf_inside_formation: '!n'
       - not_equal: ['!a', 'φ']
       - absent_attrs:
           attrs: ['!a']
@@ -149,7 +147,7 @@ rules:
     tests:
       - name: 'Attribute does not exist'
         input: '⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧.b'
-        output: ['⟦ ρ ↦ ⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧ ⟧.b']
+        output: ['⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧.φ.b']
       - name: 'Attribute exists'
         input: '⟦ φ ↦ ⟦ ⟧, a ↦ ⟦ ⟧ ⟧.a'
         output: []


### PR DESCRIPTION
As discussed in https://github.com/yegor256/phi-paper/pull/34, we can update the decoration rule to insert `.φ`.

In this version of the rule, it coincides with the corresponding rule in the minimal `φ`-calculus.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the `yegor.yaml` file in the `eo/phi/rules` directory to improve object attribute access logic.

### Detailed summary
- Simplified object attribute access pattern
- Updated result format for object attribute access
- Added conditions for attribute presence and absence
- Updated test cases for attribute existence and non-existence

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->