### PR TITLE
Experiment with closure of objects

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -50,7 +50,7 @@ import Language.EO.Phi.Pipeline.EOTests.PrepareTests (prepareTests)
 import Language.EO.Phi.Report.Data (makeProgramReport, makeReport)
 import Language.EO.Phi.Report.Html (reportCSS, reportJS, toStringReport)
 import Language.EO.Phi.Rules.Common
-import Language.EO.Phi.Rules.Fast (fastYegorInsideOut, fastYegorInsideOutAsRule)
+import Language.EO.Phi.Rules.Delayed (delayedYegorInsideOut, delayedYegorInsideOutAsRule)
 import Language.EO.Phi.Rules.Yaml (RuleSet (rules, title), convertRuleNamed, parseRuleSetFromFile)
 import Language.EO.Phi.ToLaTeX
 import Main.Utf8
@@ -454,7 +454,7 @@ main = withUtf8 do
           Just path -> do
             ruleSet <- parseRuleSetFromFile path
             return (False, ruleSet.title, convertRuleNamed <$> ruleSet.rules)
-          Nothing -> return (True, "Yegor's rules (builtin)", [fastYegorInsideOutAsRule])
+          Nothing -> return (True, "Yegor's rules (builtin)", [delayedYegorInsideOutAsRule])
       unless (single || json) $ logStrLn ruleSetTitle
       bindingsWithDeps <- case deepMergePrograms (program' : deps) of
         Left err -> throw (CouldNotMergeDependencies err)
@@ -463,7 +463,7 @@ main = withUtf8 do
           uniqueResults
             -- Something here seems incorrect
             | chain = map fst $ applyRulesChainWith' limits ctx (Formation bindings)
-            | builtin = return [LogEntry "" (fastYegorInsideOut ctx (Formation bindings)) 0]
+            | builtin = return [LogEntry "" (delayedYegorInsideOut ctx (Formation bindings)) 0]
             | otherwise = (\x -> [LogEntry "" x 0]) <$> applyRulesWith limits ctx (Formation bindings)
            where
             limits = ApplicationLimits maxDepth (maxGrowthFactor * objectSize (Formation bindings))
@@ -519,7 +519,7 @@ main = withUtf8 do
           Just path -> do
             ruleSet <- parseRuleSetFromFile path
             return (False, ruleSet.title, convertRuleNamed <$> ruleSet.rules)
-          Nothing -> return (True, "Yegor's rules (builtin)", [fastYegorInsideOutAsRule])
+          Nothing -> return (True, "Yegor's rules (builtin)", [delayedYegorInsideOutAsRule])
       let (Program bindings) = program'
           inputObject
             | asPackage = Formation (injectLamdbaPackage bindings)
@@ -547,7 +547,7 @@ main = withUtf8 do
             else do
               forM_ (fst (dataizeChain ctx inputObject)) $ \LogEntry{..} ->
                 case logEntryLog of
-                  Left obj -> logStrLn (replicate logEntryLevel ' ' ++ logEntryMessage ++ ": " ++ printTree obj)
+                  Left obj -> logStrLn (replicate logEntryLevel ' ' ++ logEntryMessage ++ ": " ++ printTree (hideRho obj))
                   Right (Bytes bytes) -> logStrLn (replicate logEntryLevel ' ' ++ logEntryMessage ++ ": " ++ bytes)
         else do
           let dataize

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -125,6 +125,7 @@ library
       Language.EO.Phi.Report.Data
       Language.EO.Phi.Report.Html
       Language.EO.Phi.Rules.Common
+      Language.EO.Phi.Rules.Delayed
       Language.EO.Phi.Rules.Fast
       Language.EO.Phi.Rules.PhiPaper
       Language.EO.Phi.Rules.Yaml
@@ -225,6 +226,7 @@ test-suite doctests
       Language.EO.Phi.Report.Data
       Language.EO.Phi.Report.Html
       Language.EO.Phi.Rules.Common
+      Language.EO.Phi.Rules.Delayed
       Language.EO.Phi.Rules.Fast
       Language.EO.Phi.Rules.PhiPaper
       Language.EO.Phi.Rules.Yaml

--- a/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Dataize.hs
@@ -17,7 +17,7 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (listToMaybe)
 import Language.EO.Phi (printTree)
 import Language.EO.Phi.Rules.Common
-import Language.EO.Phi.Rules.Fast (fastYegorInsideOut)
+import Language.EO.Phi.Rules.Delayed (delayedYegorInsideOut)
 import Language.EO.Phi.Rules.Yaml (substThis)
 import Language.EO.Phi.Syntax.Abs
 import PyF (fmt)
@@ -110,7 +110,7 @@ dataizeRecursivelyChain = fmap minimizeObject' . go
     let limits = defaultApplicationLimits (objectSize globalObject)
     let normalizedObj
           | builtinRules ctx = do
-              let obj' = fastYegorInsideOut ctx obj
+              let obj' = delayedYegorInsideOut ctx obj
               logStep "Normalized" obj'
               return obj'
           | otherwise = applyRulesChainWith limits obj

--- a/eo-phi-normalizer/src/Language/EO/Phi/Rules/Delayed.hs
+++ b/eo-phi-normalizer/src/Language/EO/Phi/Rules/Delayed.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Language.EO.Phi.Rules.Delayed where
+
+import Data.List (partition)
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NonEmpty
+import Language.EO.Phi.Rules.Common
+import Language.EO.Phi.Syntax.Abs
+
+-- $setup
+-- >>> :set -XOverloadedStrings
+
+data ObjectClosure
+  = FormationC Env [Binding]
+  | ApplicationC ObjectClosure [BindingClosure]
+  | ObjectDispatchC ObjectClosure Attribute
+  | TerminationC
+
+data BindingClosure
+  = AlphaBindingC Attribute ObjectClosure
+  | DeltaBindingC Bytes
+
+type Env = NonEmpty ObjectClosure
+
+evalContext :: Context -> Env
+evalContext ctx = go (outerFormations ctx)
+ where
+  go :: NonEmpty Object -> NonEmpty ObjectClosure
+  go (Formation bindings :| []) = globalClosure :| []
+   where
+    globalClosure = FormationC (globalClosure :| []) bindings
+  go (_ :| []) = error "non-formation as global object"
+  go (x :| (y : ys)) = let env = go (y :| ys) in eval env x `NonEmpty.cons` env
+
+delayedYegorInsideOut :: Context -> Object -> Object
+delayedYegorInsideOut ctx = quote . eval (evalContext ctx)
+
+delayedYegorInsideOutAsRule :: NamedRule
+delayedYegorInsideOutAsRule = ("Yegor's rules (hardcoded, with delayed substitutions)", \ctx obj -> [delayedYegorInsideOut ctx obj])
+
+-- evaluate object into closure
+eval :: Env -> Object -> ObjectClosure
+eval env = \case
+  Formation bindings -> FormationC env bindings
+  Application obj args -> applicationClosure (eval env obj) (map (evalBinding env) args)
+  ObjectDispatch obj attr -> objectDispatchClosure (eval env obj) attr
+  GlobalObject -> NonEmpty.last env
+  ThisObject -> NonEmpty.head env
+  Termination -> TerminationC
+  MetaSubstThis{} -> error "cannot evaluate an object with meta subst"
+  MetaObject{} -> error "cannot evaluate an object with metavariables"
+  MetaFunction{} -> error "cannot evaluate an object with metafunctions"
+
+evalBinding :: Env -> Binding -> BindingClosure
+evalBinding env = \case
+  AlphaBinding attr obj -> AlphaBindingC attr (eval env obj)
+  DeltaBinding bytes -> DeltaBindingC bytes
+  _ -> error "cannot evaluate empty of meta bindings"
+
+-- recover object from closure
+quote :: ObjectClosure -> Object
+quote = \case
+  FormationC _env bindings -> Formation bindings -- is it really that simple?
+  ObjectDispatchC objC attr -> ObjectDispatch (quote objC) attr
+  ApplicationC obj args -> Application (quote obj) (map quoteBinding args)
+  TerminationC -> Termination
+
+quoteBinding :: BindingClosure -> Binding
+quoteBinding = \case
+  AlphaBindingC attr objC -> AlphaBinding attr (quote objC)
+  DeltaBindingC bytes -> DeltaBinding bytes
+
+objectDispatchClosure :: ObjectClosure -> Attribute -> ObjectClosure
+objectDispatchClosure objC a =
+  case objC of
+    FormationC env bindings ->
+      case lookupBinding a bindings of
+        Just objA -> eval (objC `NonEmpty.cons` env) objA
+        Nothing ->
+          case lookupBinding Phi bindings of
+            Just objPhi -> eval (objC `NonEmpty.cons` env) (ObjectDispatch objPhi a)
+            Nothing
+              | not (any isLambdaBinding bindings) -> TerminationC
+              | otherwise -> ObjectDispatchC objC a
+    _ -> ObjectDispatchC objC a
+
+splitPositionalArgs :: [BindingClosure] -> ([ObjectClosure], [BindingClosure])
+splitPositionalArgs = go
+ where
+  go [] = ([], [])
+  go (AlphaBindingC (Alpha _) obj : args) = (obj : objs, others)
+   where
+    (objs, others) = go args
+  go (bindingC : args) = (objs, bindingC : others)
+   where
+    (objs, others) = go args
+
+applicationBindingsClosure :: Env -> [BindingClosure] -> [Binding] -> ObjectClosure
+applicationBindingsClosure env args bindings
+  | length args > length emptyBindings
+      || length leftoverEmptyBindings + length args > length emptyBindings =
+      TerminationC
+  | otherwise =
+      FormationC env $
+        concat
+          [ zipWith f emptyBindings (map quote positionalArgs)
+          , map quoteBinding otherArgs
+          , attachedBindings
+          ]
+ where
+  f (EmptyBinding a) = AlphaBinding a
+  f _ = error "impossible: not an empty (non-Δ) binding!"
+
+  (positionalArgs, otherArgs) = splitPositionalArgs args
+  (emptyBindings, attachedBindings) = partition isEmptyBinding bindings
+  leftoverEmptyBindings = filter doesNotHaveArg (drop (length positionalArgs) emptyBindings)
+  doesNotHaveArg (EmptyBinding a) =
+    a
+      `notElem` [argAttr | AlphaBindingC argAttr _ <- otherArgs]
+  doesNotHaveArg _ = error "impossible: not an empty (non-Δ) binding"
+
+applicationClosure :: ObjectClosure -> [BindingClosure] -> ObjectClosure
+applicationClosure objC args =
+  case objC of
+    FormationC env bindings -> applicationBindingsClosure env args bindings
+    _ -> ApplicationC objC args
+
+isLambdaBinding :: Binding -> Bool
+isLambdaBinding LambdaBinding{} = True
+isLambdaBinding _ = False


### PR DESCRIPTION
This is an experiment to see if we can speed up computation and improve the final object representation:

- [ ] Introduce closure for objects.
- [ ] Implement (standard) rules via closures.
- [ ] Improve conversion from closures to attach (and reuse) $\rho$-attributes to temporary objects in the global formation