### PR TITLE
Update the `COPY` rule as in phi-paper

### DIFF
--- a/eo-phi-normalizer/test/eo/phi/dataization.yaml
+++ b/eo-phi-normalizer/test/eo/phi/dataization.yaml
@@ -95,7 +95,15 @@ tests:
       {⟦ x ↦ ⟦ c ↦ ⟦ a ↦ ∅ ⟧ (a ↦ ⟦ d ↦ ξ.ρ ⟧) ⟧.c , λ ⤍ Package ⟧}
     output:
       object: |
-        ⟦ x ↦ ⟦ a ↦ ⟦ d ↦ ξ.ρ ⟧, ρ ↦ ⟦ c ↦ ⟦ a ↦ ⟦ d ↦ ξ.ρ ⟧ ⟧ ⟧ ⟧, λ ⤍ Package ⟧
+        ⟦ x ↦ ⟦
+            a ↦ ⟦
+              d ↦ ξ.ρ,
+              ρ ↦ ⟦ c ↦ ⟦ a ↦ ∅ ⟧(a ↦ ⟦ d ↦ ξ.ρ ⟧) ⟧
+            ⟧,
+            ρ ↦ ⟦ c ↦ ⟦ a ↦ ∅ ⟧(a ↦ ⟦ d ↦ ξ.ρ ⟧) ⟧
+          ⟧,
+          λ ⤍ Package
+        ⟧
 
   - name: "Object with ξ.ρ is an argument in application"
     dependencies: []

--- a/eo-phi-normalizer/test/eo/phi/dataization.yaml
+++ b/eo-phi-normalizer/test/eo/phi/dataization.yaml
@@ -117,14 +117,25 @@ tests:
       object: |
         ⟦ a ↦ ⟦ Δ ⤍ 02- ⟧, x ↦ ⟦ Δ ⤍ 02- ⟧, λ ⤍ Package ⟧
 
-  # FIXME: fails because nf condition for ξ.b succeeds though it shouldn't
-  # - name: "ξ in application"
-  #   dependencies: []
-  #   input: |
-  #     {⟦ x ↦ ⟦ a ↦ ∅ ⟧(a ↦ ξ.b), b ↦ ⟦ Δ ⤍ 01- ⟧ , λ ⤍ Package ⟧}
-  #   output:
-  #     object: |
-  #       {⟦ x ↦ ⟦ a ↦ ⟦ Δ ⤍ 01- ⟧ ⟧, b ↦ ⟦ Δ ⤍ 01- ⟧ , λ ⤍ Package ⟧}
+  - name: "ξ in application"
+    dependencies: []
+    input: |
+      {⟦ x ↦ ⟦ a ↦ ∅ ⟧(a ↦ ξ.b), b ↦ ⟦ Δ ⤍ 01- ⟧ , λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ x ↦ ⟦
+            a ↦ ⟦
+              Δ ⤍ 01-,
+              ρ ↦ ⟦
+                b ↦ ⟦ Δ ⤍ 01- ⟧,
+                x ↦ ⟦ a ↦ ∅ ⟧ (a ↦ ξ.b),
+                λ ⤍ Package
+              ⟧
+            ⟧
+          ⟧,
+          b ↦ ⟦ Δ ⤍ 01- ⟧,
+          λ ⤍ Package
+        ⟧
 
   - name: "ξ chain"
     dependencies: []

--- a/eo-phi-normalizer/test/eo/phi/dataization.yaml
+++ b/eo-phi-normalizer/test/eo/phi/dataization.yaml
@@ -97,6 +97,14 @@ tests:
       object: |
         ⟦ x ↦ ⟦ a ↦ ⟦ d ↦ ξ.ρ ⟧, ρ ↦ ⟦ c ↦ ⟦ a ↦ ⟦ d ↦ ξ.ρ ⟧ ⟧ ⟧ ⟧, λ ⤍ Package ⟧
 
+  - name: "Object with ξ.ρ is an argument in application"
+    dependencies: []
+    input: |
+      {⟦ a ↦ ⟦ b ↦ ∅, x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ (b ↦ ⟦ c ↦ ξ.ρ.x ⟧ ).b.c, x ↦ ⟦ Δ ⤍ 02- ⟧, λ ⤍ Package ⟧}
+    output:
+      object: |
+        ⟦ a ↦ ⟦ Δ ⤍ 02- ⟧, x ↦ ⟦ Δ ⤍ 02- ⟧, λ ⤍ Package ⟧
+
   # FIXME: fails because nf condition for ξ.b succeeds though it shouldn't
   # - name: "ξ in application"
   #   dependencies: []

--- a/eo-phi-normalizer/test/eo/phi/dataization.yaml
+++ b/eo-phi-normalizer/test/eo/phi/dataization.yaml
@@ -100,7 +100,11 @@ tests:
   - name: "Object with ξ.ρ is an argument in application"
     dependencies: []
     input: |
-      {⟦ a ↦ ⟦ b ↦ ∅, x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ (b ↦ ⟦ c ↦ ξ.ρ.x ⟧ ).b.c, x ↦ ⟦ Δ ⤍ 02- ⟧, λ ⤍ Package ⟧}
+      {⟦
+        a ↦ ⟦ b ↦ ∅, x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ (b ↦ ⟦ c ↦ ξ.ρ.x ⟧ ).b.c,
+        x ↦ ⟦ Δ ⤍ 02- ⟧,
+        λ ⤍ Package
+      ⟧}
     output:
       object: |
         ⟦ a ↦ ⟦ Δ ⤍ 02- ⟧, x ↦ ⟦ Δ ⤍ 02- ⟧, λ ⤍ Package ⟧

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -119,13 +119,24 @@ rules:
 
   - name: R_COPY
     description: 'Application of α-binding'
+    context:
+      current_object: "!b3"
     pattern: |
-      ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !b, !B2), !B3 ⟧
+      ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !b, !B2)
     result: |
-      ⟦ !τ1 ↦ ⟦ !τ2 ↦ !b[ ξ ↦ ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !b, !B2), !B3 ⟧ ], !B1 ⟧(!B2), !B3 ⟧
+      ⟦ !τ2 ↦ !b[ ξ ↦ !b3 ], !B1 ⟧(!B2)
     when:
-      - apply_in_abstract_subformations: false
+      - apply_in_subformations: false
       - nf: '!b'
+    tests: []
+
+  - name: R_COPY_EMPTY
+    description: 'Empty application'
+    pattern: |
+      ⟦ !B1 ⟧()
+    result: |
+      ⟦ !B1 ⟧
+    when: []
     tests: []
 
   - name: R_COPY_Δ

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -125,7 +125,7 @@ rules:
       ⟦ !τ1 ↦ ⟦ !τ2 ↦ !n[ ξ ↦ ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !n, !B2), !B3 ⟧ ], !B1 ⟧(!B2), !B3 ⟧
     when:
       - apply_in_abstract_subformations: false
-      - nf: '!b'
+      - nf: '!n'
     tests: []
 
   - name: R_COPY_Δ

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -93,12 +93,14 @@ rules:
     # Warning: this is not correct for the chain variant because it only matches the first two bindings
     # i.e., doesn't match an empty binding after an attached one.
     # We should instead match the first two empty bindings.
+    context:
+      current_object: "!b_cur"
     pattern: |
       ⟦ !τ1 ↦ ∅, !τ2 ↦ ∅, !B ⟧(α0 ↦ !b0, α1 ↦ !b1)
     result: |
-      ⟦ !τ1 ↦ !b0, !τ2 ↦ !b1, !B ⟧
+      ⟦ !τ1 ↦ !b0[ ξ ↦ !b_cur ], !τ2 ↦ !b1[ ξ ↦ !b_cur ], !B ⟧
     when:
-      - apply_in_abstract_subformations: false
+      - apply_in_subformations: false
       - nf: '!b0'
       - nf: '!b1'
     tests: []
@@ -108,23 +110,25 @@ rules:
     # Warning: this is not correct for the chain variant because it only matches the first binding
     # i.e., doesn't match an empty binding after an attached one.
     # We should instead match the first empty binding.
+    context:
+      current_object: "!b_cur"
     pattern: |
       ⟦ !τ ↦ ∅, !B ⟧(α0 ↦ !b)
     result: |
-      ⟦ !τ ↦ !b, !B ⟧
+      ⟦ !τ ↦ !b[ ξ ↦ !b_cur ], !B ⟧
     when:
-      - apply_in_abstract_subformations: false
+      - apply_in_subformations: false
       - nf: '!b'
     tests: []
 
   - name: R_COPY
     description: 'Application of α-binding'
     context:
-      current_object: "!b3"
+      current_object: "!b_cur"
     pattern: |
-      ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !b, !B2)
+      ⟦ !τ ↦ ∅, !B1 ⟧(!τ ↦ !b, !B2)
     result: |
-      ⟦ !τ2 ↦ !b[ ξ ↦ !b3 ], !B1 ⟧(!B2)
+      ⟦ !τ ↦ !b[ ξ ↦ !b_cur ], !B1 ⟧(!B2)
     when:
       - apply_in_subformations: false
       - nf: '!b'

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -120,12 +120,12 @@ rules:
   - name: R_COPY
     description: 'Application of α-binding'
     pattern: |
-      ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !n, !B2), !B3 ⟧
+      ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !b, !B2), !B3 ⟧
     result: |
-      ⟦ !τ1 ↦ ⟦ !τ2 ↦ !n[ ξ ↦ ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !n, !B2), !B3 ⟧ ], !B1 ⟧(!B2), !B3 ⟧
+      ⟦ !τ1 ↦ ⟦ !τ2 ↦ !b[ ξ ↦ ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !b, !B2), !B3 ⟧ ], !B1 ⟧(!B2), !B3 ⟧
     when:
       - apply_in_abstract_subformations: false
-      - nf: '!n'
+      - nf: '!b'
     tests: []
 
   - name: R_COPY_Δ

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -120,9 +120,9 @@ rules:
   - name: R_COPY
     description: 'Application of α-binding'
     pattern: |
-      ⟦ !τ ↦ ∅, !B ⟧(!τ ↦ !b)
+      ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !n, !B2), !B3 ⟧
     result: |
-      ⟦ !τ ↦ !b, !B ⟧
+      ⟦ !τ1 ↦ ⟦ !τ2 ↦ !n[ ξ ↦ ⟦ !τ1 ↦ ⟦ !τ2 ↦ ∅, !B1 ⟧(!τ2 ↦ !n, !B2), !B3 ⟧ ], !B1 ⟧(!B2), !B3 ⟧
     when:
       - apply_in_abstract_subformations: false
       - nf: '!b'


### PR DESCRIPTION
The current version of `R_COPY` does not account for the case when the inserted term is a formation that makes use of it's `ρ` attribute. As a result, when moving such formation inside the copied one, `ξ.ρ` changes, though it shouldn't.

Running recursive dataization on this term
```
{
  ⟦
    a ↦ ⟦ b ↦ ∅, x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ (b ↦ ⟦ c ↦ ξ.ρ.x ⟧ ).b.c,
    x ↦ ⟦ Δ ⤍ 02- ⟧,
    λ ⤍ Package
  ⟧
}
```

results in
```
⟦ a ↦ ⟦ Δ ⤍ 01- ⟧,
  x ↦ ⟦ Δ ⤍ 02- ⟧,
  λ ⤍ Package
⟧
```

while the expected result is
```
⟦ a ↦ ⟦ Δ ⤍ 02- ⟧,
  x ↦ ⟦ Δ ⤍ 02- ⟧,
  λ ⤍ Package
⟧
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating object structures and patterns in the `eo-phi-normalizer` module. 

### Detailed summary
- Updated object structures in `dataization.yaml`
- Modified patterns in `yegor.yaml`
- Added new context information
- Adjusted application rules and descriptions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->