### PR TITLE
296 update proposal process

### DIFF
--- a/proposals/000-template.md
+++ b/proposals/000-template.md
@@ -2,9 +2,9 @@
 
 [N.B: Replace text in square brackets with your text]
 
-| author             | date-accepted                         | pr-url                                          | implemented                                              |
+| author(s)             | date-accepted                         | pr-url                                          | implemented                                              |
 | ------------------ | ------------------------------------- | ----------------------------------------------- | -------------------------------------------------------- |
-| [Full author name] | [Date when the proposal was accepted] | [URL of a PR where this proposal was discussed] | [normalizer version where this proposal was implemented] |
+| [Full author names] | [Date when the proposal was accepted] | [URL of a PR where this proposal was discussed] | [normalizer version where this proposal was implemented] |
 
 ## Motivation
 

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -14,15 +14,15 @@ A proposal is a document describing a proposed change to the normalizer.
 
 ## Proposal process
 
-1. [No label] The author submits a proposal for discussion as a pull request against the `normalizer` repository ([link](https://github.com/objectionary/normalizer)).
+1. [No label] An author submits a proposal for discussion as a pull request against the `normalizer` repository ([link](https://github.com/objectionary/normalizer)).
 1. [[proposal under review](https://github.com/objectionary/normalizer/labels/proposal%20under%20review)] The `normalizer` team discusses the proposal in the commit section of the pull request, while the author refines the proposal. This phase lasts as long as necessary.
 1. Eventually, the normalizer team does one of these actions:
    1. Rejects the proposal [[proposal rejected](https://github.com/objectionary/normalizer/labels/proposal%20rejected)].
-   1. Passes the proposal back to the author for review [[proposal needs revision](https://github.com/objectionary/normalizer/labels/Proposal%20needs%20revision)].
+   1. Passes the proposal back to the author(s) for review [[proposal needs revision](https://github.com/objectionary/normalizer/labels/Proposal%20needs%20revision)].
    1. Accepts the proposal.
       - [[proposal accepted](https://github.com/objectionary/normalizer/labels/proposal%20accepted)]
       - Proposal priority - one of these labels:
         - [[proposal priority: high](https://github.com/objectionary/normalizer/labels/proposal%20priority%3A%20high)]
         - [[proposal priority: medium](https://github.com/objectionary/normalizer/labels/proposal%20priority%3A%20medium)]
         - [[proposal priority: low](https://github.com/objectionary/normalizer/labels/proposal%20priority%3A%20low)]
-1. [[proposal implemented](https://github.com/objectionary/normalizer/labels/proposal%20implemented)] Once a proposal is accepted, it still has to be implemented. The author may do that, or someone else. We mark the proposal implemented once it hits normalizer master branch (and we are happy to be nudged to do so by email, GitHub issue, or a comment on the relevant pull request), and the corresponding documentation on the site is updated.
+1. [[proposal implemented](https://github.com/objectionary/normalizer/labels/proposal%20implemented)] Once a proposal is accepted, it still has to be implemented. The author(s) may do that, or someone else. We mark the proposal implemented once it hits normalizer master branch (and we are happy to be nudged to do so by email, GitHub issue, or a comment on the relevant pull request), and the corresponding documentation on the site is updated.


### PR DESCRIPTION
- closes #296

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the proposal template and process in the `normalizer` repository to reflect changes in authorship and review responsibilities.

### Detailed summary
- Updated author field in proposal template to allow multiple authors
- Changed wording to reflect that authors submit proposals for discussion
- Updated labels and actions in the proposal process to clarify author responsibilities

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->