### PR TITLE
Add `R_DOT_ρ`

### DIFF
--- a/eo-phi-normalizer/test/eo/phi/dataization.yaml
+++ b/eo-phi-normalizer/test/eo/phi/dataization.yaml
@@ -79,7 +79,7 @@ tests:
       {⟦ x ↦ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.c ⟧.b ⟧.a , λ ⤍ Package ⟧}
     output:
       object: |
-        ⟦ x ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.ρ, ρ ↦ ⟦ ρ ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.ρ ⟧, c ↦ ξ.ρ ⟧ ⟧, λ ⤍ Package ⟧
+        ⟦ x ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.ρ, ρ ↦ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.ρ ⟧ ⟧ ⟧, λ ⤍ Package ⟧
 
   - name: "usage of Φ with a loop"
     dependencies: []

--- a/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
+++ b/eo-phi-normalizer/test/eo/phi/rules/yegor.yaml
@@ -65,12 +65,16 @@ rules:
       - apply_in_abstract_subformations: false
       - nf_inside_formation: '!b'
       - nf: '⟦ !B ⟧'
+      - not_equal: ['!τ', 'ρ']
     tests:
       - name: Should match
         input: ⟦ hello ↦ ⟦⟧ ⟧.hello
         output: ['⟦ ρ ↦ ⟦ hello ↦ ⟦⟧ ⟧ ⟧']
       - name: Shouldn't match
         input: ⟦ ⟧.hello
+        output: []
+      - name: Shouldn't match
+        input: ⟦ ρ ↦ ⟦⟧ ⟧.ρ
         output: []
       - name: Should apply in subformations
         input: ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ⟦⟧ ⟧ ⟧.b ⟧
@@ -92,6 +96,19 @@ rules:
   #     - name: Shouldn't match
   #       input: ⟦ ⟧.hello
   #       output: []
+
+  - name: R_DOT_ρ
+    description: 'Accessing ρ-binding'
+    pattern: |
+      ⟦ ρ ↦ !b, !B ⟧.ρ
+    result: |
+      !b
+    when:
+      - nf: '⟦ !B ⟧'
+    tests:
+      - name: Should match
+        input: ⟦ ρ ↦ ⟦ ⟧ ⟧.ρ
+        output: ['⟦ ⟧']
 
   - name: R_COPY2
     description: 'Application of α-binding'


### PR DESCRIPTION
Addresses https://github.com/objectionary/normalizer/issues/448.

Also fixes the `ρ and nested dispatches` test. 

This test is fixed in https://github.com/objectionary/normalizer/pull/449 but the results are different, likely because of the reductions in `ρ`.

This is a result here (1) and in #449 (2):
```
1. ⟦ x ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.ρ, ρ ↦ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.ρ ⟧ ⟧ ⟧, λ ⤍ Package ⟧
2. ⟦ x ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.ρ, ρ ↦ ⟦ a ↦ ⟦ b ↦ ⟦ c ↦ ξ.ρ ⟧.c ⟧.b ⟧ ⟧, λ ⤍ Package ⟧
```

Turns out (2) can be reduced to (1)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates dataization and rule definitions in the `eo-phi-normalizer` module. It modifies dataization output and adds a new rule for accessing ρ-binding.

### Detailed summary
- Updated dataization output in `dataization.yaml`
- Added a new rule for accessing ρ-binding in `yegor.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->