### PR TITLE
497 target directory is not auto-created

### DIFF
--- a/eo-phi-normalizer/app/Main.hs
+++ b/eo-phi-normalizer/app/Main.hs
@@ -435,7 +435,7 @@ getProgram inputFile = do
 
 getLoggers :: Maybe FilePath -> IO (String -> IO (), String -> IO ())
 getLoggers outputFile = do
-  handle <- maybe (pure stdout) (`openFile` WriteMode) outputFile
+  handle <- maybe (pure stdout) (\file -> createDirectoryIfMissing True (takeDirectory file) >> openFile file WriteMode) outputFile
   pure
     ( \x -> hPutStrLn handle x >> hFlush handle
     , \x -> hPutStr handle x >> hFlush handle


### PR DESCRIPTION
- closes #497 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `getLoggers` function in the `Main.hs` file by ensuring that the directory for the specified `outputFile` is created if it does not exist before opening the file for writing.

### Detailed summary
- Modified `getLoggers` to create the output directory if it does not exist.
- Changed the lambda function to include `createDirectoryIfMissing True (takeDirectory file)` before `openFile file WriteMode`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->