### PR TITLE
Release v1.1.0

### DIFF
--- a/eo-phi-normalizer/CHANGELOG.md
+++ b/eo-phi-normalizer/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to the
 [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## v1.1.0 - 2024-10-03
+
+### New
+
+- Add unit tests [#461](https://github.com/objectionary/normalizer/pull/461)
+- Add `R_DOT_ρ` [#468](https://github.com/objectionary/normalizer/pull/468)
+- Support printing rules in LaTeX [#474](https://github.com/objectionary/normalizer/pull/474)
+- Automatically create an output directory [#499](https://github.com/objectionary/normalizer/pull/499)
+
+### Changes and fixes
+
+- Update the `COPY` rule as in phi-paper [#445](https://github.com/objectionary/normalizer/pull/445)
+- Remove special case for delta binding since VTX is removed [#356](https://github.com/objectionary/normalizer/pull/356)
+- Replace `normalizer report` command with the `normalizer pipeline report` command [#456](https://github.com/objectionary/normalizer/pull/456)
+- Fix sorting in numeric columns [#460](https://github.com/objectionary/normalizer/pull/460)
+- Run mdbook in the pipeline job [#463](https://github.com/objectionary/normalizer/pull/463)
+
+### Documentation and maintenance
+
+- Document all dependencies in a single doc in `eo/phi/normalizer/data` for each eo version [#446](https://github.com/objectionary/normalizer/pull/446).
+- Create a metrics page on the site [#453](https://github.com/objectionary/normalizer/pull/453)
+- Chore(deps): update dependency pre-commit to v3.8.0 [#455](https://github.com/objectionary/normalizer/pull/455)
+- Provide instructions for the customer to check that we've completed the contract requirements [#458](https://github.com/objectionary/normalizer/pull/458)
+- Bump stack action version [#459](https://github.com/objectionary/normalizer/pull/459)
+- Update proposal process [#464](https://github.com/objectionary/normalizer/pull/464)
+- Document creating custom atoms on the site [#467](https://github.com/objectionary/normalizer/pull/467)
+
 ## v1.0.0 - 2024-07-19
 
 ### New

--- a/eo-phi-normalizer/eo-phi-normalizer.cabal
+++ b/eo-phi-normalizer/eo-phi-normalizer.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           eo-phi-normalizer
-version:        1.0.0
+version:        1.1.0
 synopsis:       Command line normalizer of 𝜑-calculus expressions.
 description:    Please see the README on GitHub at <https://github.com/objectionary/eo-phi-normalizer#readme>
 homepage:       https://github.com/objectionary/eo-phi-normalizer#readme

--- a/eo-phi-normalizer/package.yaml
+++ b/eo-phi-normalizer/package.yaml
@@ -1,6 +1,6 @@
 name: eo-phi-normalizer
 synopsis: "Command line normalizer of 𝜑-calculus expressions."
-version: 1.0.0
+version: 1.1.0
 github: "objectionary/eo-phi-normalizer"
 license: BSD3
 author: "EO/Polystat Development Team"


### PR DESCRIPTION
- Related to #500 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `eo-phi-normalizer` package to version `1.1.0`, introducing new features, changes, and fixes, along with documentation improvements.

### Detailed summary
- Updated version to `1.1.0` in `package.yaml` and `eo-phi-normalizer.cabal`
- Added unit tests
- Introduced `R_DOT_ρ`
- Enabled LaTeX printing of rules
- Automated output directory creation
- Updated `COPY` rule
- Removed delta binding special case
- Replaced `normalizer report` with `normalizer pipeline report`
- Fixed numeric column sorting
- Integrated `mdbook` in pipeline job
- Documented dependencies in `eo/phi/normalizer/data`
- Created a metrics page
- Updated `pre-commit` dependency
- Provided contract completion instructions
- Bumped stack action version
- Updated proposal process
- Documented custom atoms creation

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->